### PR TITLE
:ok_hand: [#26] -- addressed remaining PR feedback

### DIFF
--- a/src/lib/validation/validate.ts
+++ b/src/lib/validation/validate.ts
@@ -74,11 +74,10 @@ export const getFormErrors = async (
   }
 };
 
-function isScalarValue(obj: IValues | Value | Values): obj is Value {
-  if (Array.isArray(obj)) return false;
-  if (obj == null) return true;
+const isSingleValue = (obj: IValues | Value | Values): obj is Value => {
+  if (obj === null) return true; // typeof null === 'object'
   return typeof obj !== 'object';
-}
+};
 
 /**
  * Validates `form`.
@@ -114,15 +113,17 @@ export const validateForm = async (
     const key = component.key || OF_MISSING_KEY;
     // lodash.get like to support nested data structures/keys with dots
     // TODO: works only for objects right now
-    // FIXME: types can be more complex, value of a file upload is not a scaler, but an
+    // FIXME: types can be more complex, value of a file upload is not a scalar, but an
     // object!
+    // FIXME: the accumulator casting is also less than ideal, it should be possible
+    // to infer this correctly.
     const value = key.split('.').reduce((acc: Value | IValues, bit: string) => {
       if (Array.isArray(acc)) {
         throw new Error('Arrays not supported yet');
       }
       if (acc === null) return null;
       const nestedProp = (acc as IValues)[bit];
-      if (isScalarValue(nestedProp)) {
+      if (isSingleValue(nestedProp)) {
         return nestedProp;
       }
       return nestedProp;

--- a/src/types/value.d.ts
+++ b/src/types/value.d.ts
@@ -1,3 +1,15 @@
+/*
+ TODO: value types need some overhaul, ideally we make them formio component type
+ specific through a generic mechanisms. E.g. the value of a file component is
+ *always* an array of objects, while the value of a checkbox is a boolean (possibly
+ null?).
+
+ Next, the formio component schema allows keys to be specified as foo.bar which
+ results in a {"foo": {"bar": <value>}} datastructure. Due to their not being a
+ well-defined, guaranteed mechanism for not-filled out fields, it's possible that
+ certain (sub) keys are missing and lookups result in 'undefined'.
+*/
+
 export type Value = boolean | number | string | null;
 
 export type Values = Value[];


### PR DESCRIPTION
* Rewrote and renamed the isScalarValue type predicate as arrow func
* Added more TODOs and FIXMEs regarding the component value types
* Made null check strict, as typeof undefined is undefined and not object
* Removed redundant Array.isArray check