### PR TITLE
Port phone number component from SDK

### DIFF
--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -13,5 +13,10 @@
     "defaultMessage": "A BSN must be 9 digits",
     "description": "Validation error describing shape of BSN.",
     "originalDefault": "A BSN must be 9 digits"
+  },
+  "sP3xMn": {
+    "defaultMessage": "Invalid phone number - a phone number may only contain digits, the + or - sign or spaces",
+    "description": "Validation error for phone number format.",
+    "originalDefault": "Invalid phone number - a phone number may only contain digits, the + or - sign or spaces"
   }
 }

--- a/i18n/messages/nl.json
+++ b/i18n/messages/nl.json
@@ -13,5 +13,10 @@
     "defaultMessage": "Een BSN moet uit 9 cijfers bestaan",
     "description": "Validation error describing shape of BSN.",
     "originalDefault": "A BSN must be 9 digits"
+  },
+  "sP3xMn": {
+    "defaultMessage": "Ongeldig telefoonnummer - je mag enkel cijfers, de + of - tekens en spaties gebruiken. Bijvoorbeeld +316 123-456-78.",
+    "description": "Validation error for phone number format.",
+    "originalDefault": "Invalid phone number - a phone number may only contain digits, the + or - sign or spaces"
   }
 }

--- a/src/registry/phoneNumber/index.stories.tsx
+++ b/src/registry/phoneNumber/index.stories.tsx
@@ -1,0 +1,160 @@
+import {PhoneNumberComponentSchema} from '@open-formulieren/types';
+import type {Meta, StoryObj} from '@storybook/react';
+import {expect, fn, userEvent, within} from '@storybook/test';
+
+import FormioForm, {FormioFormProps} from '@/components/FormioForm';
+import {withFormik} from '@/sb-decorators';
+
+import {PhoneNumberField} from './';
+
+export default {
+  title: 'Component registry / basic / phoneNumber',
+  component: PhoneNumberField,
+  decorators: [withFormik],
+} satisfies Meta<typeof PhoneNumberField>;
+
+type Story = StoryObj<typeof PhoneNumberField>;
+
+export const MinimalConfiguration: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'phoneNumber',
+      key: 'my.phoneNumber',
+      label: 'A simple phone number',
+      inputMask: null,
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          phoneNumber: '',
+        },
+      },
+    },
+  },
+};
+
+export const WithPlaceholder: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'phoneNumber',
+      key: 'phoneNumber',
+      label: 'A simple phone number',
+      placeholder: '123-456 789',
+      inputMask: null,
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        phoneNumber: '',
+      },
+    },
+  },
+};
+
+export const WithAutocomplete: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'phoneNumber',
+      key: 'phoneNumber',
+      label: 'A simple phone number',
+      autocomplete: 'tel',
+      inputMask: null,
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        phoneNumber: '',
+      },
+    },
+  },
+};
+
+interface ValidationStoryArgs {
+  componentDefinition: PhoneNumberComponentSchema;
+  onSubmit: FormioFormProps['onSubmit'];
+}
+
+type ValidationStory = StoryObj<ValidationStoryArgs>;
+
+const BaseValidationStory: ValidationStory = {
+  render: args => (
+    <FormioForm
+      onSubmit={args.onSubmit}
+      components={[args.componentDefinition]}
+      requiredFieldsWithAsterisk
+    >
+      <div style={{marginBlockStart: '20px'}}>
+        <button type="submit">Submit</button>
+      </div>
+    </FormioForm>
+  ),
+  parameters: {
+    formik: {
+      disable: true,
+    },
+  },
+};
+
+export const ValidateRequired: ValidationStory = {
+  ...BaseValidationStory,
+  args: {
+    onSubmit: fn(),
+    componentDefinition: {
+      id: 'component1',
+      type: 'phoneNumber',
+      key: 'my.phoneNumber',
+      label: 'A phone number',
+      inputMask: null,
+      validate: {
+        required: true,
+      },
+    } satisfies PhoneNumberComponentSchema,
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const phoneNumberField = canvas.getByLabelText('A phone number');
+    expect(phoneNumberField).toBeVisible();
+
+    await userEvent.click(canvas.getByRole('button', {name: 'Submit'}));
+    expect(await canvas.findByText('Required')).toBeVisible();
+  },
+};
+
+export const ValidatePattern: ValidationStory = {
+  ...BaseValidationStory,
+  args: {
+    onSubmit: fn(),
+    componentDefinition: {
+      id: 'component1',
+      type: 'phoneNumber',
+      key: 'my.phoneNumber',
+      label: 'A phone number',
+      inputMask: null,
+      validate: {
+        required: false,
+      },
+    } satisfies PhoneNumberComponentSchema,
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const phoneNumberField = canvas.getByLabelText('A phone number');
+    expect(phoneNumberField).toBeVisible();
+    await userEvent.type(phoneNumberField, 'not-a phone number');
+
+    await userEvent.click(canvas.getByRole('button', {name: 'Submit'}));
+    expect(
+      await canvas.findByText(
+        'Invalid phone number - a phone number may only contain digits, the + or - sign or spaces'
+      )
+    ).toBeVisible();
+  },
+};

--- a/src/registry/phoneNumber/index.tsx
+++ b/src/registry/phoneNumber/index.tsx
@@ -1,0 +1,43 @@
+import type {PhoneNumberComponentSchema} from '@open-formulieren/types';
+
+import TextField from '@/components/forms/TextField';
+import type {RegistryEntry} from '@/registry/types';
+
+import getInitialValues from './initialValues';
+import getValidationSchema from './validationSchema';
+
+export interface PhoneNumberFieldProps {
+  componentDefinition: PhoneNumberComponentSchema;
+}
+
+/**
+ * A component to enter phone numbers.
+ *
+ * @todo - this is deprecated in the Open-Forms-SDk - check what we can do with this
+ * component.
+ * @deprecated - ideally we should be able to use textfield with the appropriate
+ * validators.
+ */
+export const PhoneNumberField: React.FC<PhoneNumberFieldProps> = ({
+  componentDefinition: {key, label, description, placeholder, validate, autocomplete},
+}) => {
+  return (
+    <TextField
+      name={key}
+      label={label}
+      description={description}
+      isRequired={validate?.required}
+      placeholder={placeholder}
+      pattern="^[+0-9][- 0-9]+$"
+      autoComplete={autocomplete}
+    />
+  );
+};
+
+const PhoneNumberComponent: RegistryEntry<PhoneNumberComponentSchema> = {
+  formField: PhoneNumberField,
+  getInitialValues,
+  getValidationSchema,
+};
+
+export default PhoneNumberComponent;

--- a/src/registry/phoneNumber/initialValues.ts
+++ b/src/registry/phoneNumber/initialValues.ts
@@ -1,0 +1,18 @@
+import type {PhoneNumberComponentSchema} from '@open-formulieren/types';
+
+import type {GetInitialValues} from '@/registry/types';
+
+const getInitialValues: GetInitialValues<PhoneNumberComponentSchema, string | string[]> = ({
+  key,
+  defaultValue,
+  multiple = false,
+}: PhoneNumberComponentSchema) => {
+  // if no default value is explicitly specified, return the empty value, depending on
+  // whether it's multiple false/true on this component.
+  if (defaultValue === undefined) {
+    defaultValue = multiple ? [] : '';
+  }
+  return {[key]: defaultValue};
+};
+
+export default getInitialValues;

--- a/src/registry/phoneNumber/validationSchema.spec.ts
+++ b/src/registry/phoneNumber/validationSchema.spec.ts
@@ -1,0 +1,73 @@
+import type {PhoneNumberComponentSchema} from '@open-formulieren/types';
+import {createIntl} from 'react-intl';
+
+import {getRegistryEntry} from '@/registry/registry';
+
+import getValidationSchema from './validationSchema';
+
+const intl = createIntl({locale: 'en', messages: {}});
+
+const BASE_COMPONENT: PhoneNumberComponentSchema = {
+  type: 'phoneNumber',
+  id: 'phoneNumber',
+  key: 'phoneNumber',
+  label: 'Phone number',
+  inputMask: null,
+};
+
+const buildValidationSchema = (component: PhoneNumberComponentSchema) => {
+  const schemas = getValidationSchema(component, intl, getRegistryEntry);
+  return schemas[component.key];
+};
+
+describe('phoneNumber component validation', () => {
+  test.each([124, false, true, ['array'], null, {object: 'value'}])(
+    'does not accept non-string values (value: %s)',
+    value => {
+      const schema = buildValidationSchema(BASE_COMPONENT);
+
+      const {success} = schema.safeParse(value);
+
+      expect(success).toBe(false);
+    }
+  );
+
+  test.each([
+    [false, ''],
+    [false, undefined],
+    [true, ''],
+    [true, undefined],
+  ])('required %s (value: %s)', (required, value) => {
+    const component: PhoneNumberComponentSchema = {...BASE_COMPONENT, validate: {required}};
+    const schema = buildValidationSchema(component);
+
+    const {success} = schema.safeParse(value);
+
+    expect(success).toBe(!required);
+  });
+
+  test.each(['123456789', '+31 6 11223344', '0031 6 11223344', '06 112 233 44', '06-112-23-44'])(
+    'valid formats (value: %s)',
+    value => {
+      const schema = buildValidationSchema(BASE_COMPONENT);
+
+      const {success} = schema.safeParse(value);
+
+      expect(success).toBe(true);
+    }
+  );
+
+  test.each([
+    ['06-[0-9]+', '06-12345678', true],
+    ['06-[0-9]+', '06 12345678', false],
+    ['^\\+31.*$', '+31202020', true],
+    ['^\\+31.*$', '0202020', false],
+  ])('accepts additional pattern %s (value: %s)', (pattern, value, valid) => {
+    const component: PhoneNumberComponentSchema = {...BASE_COMPONENT, validate: {pattern}};
+    const schema = buildValidationSchema(component);
+
+    const {success} = schema.safeParse(value);
+
+    expect(success).toBe(valid);
+  });
+});

--- a/src/registry/phoneNumber/validationSchema.ts
+++ b/src/registry/phoneNumber/validationSchema.ts
@@ -1,0 +1,43 @@
+import type {PhoneNumberComponentSchema} from '@open-formulieren/types';
+import {defineMessage} from 'react-intl';
+import {z} from 'zod';
+
+import type {GetValidationSchema} from '@/registry/types';
+
+const PHONE_NUMBER_INVALID_MESSAGE = defineMessage({
+  description: 'Validation error for phone number format.',
+  defaultMessage:
+    'Invalid phone number - a phone number may only contain digits, the + or - sign or spaces',
+});
+
+const getValidationSchema: GetValidationSchema<PhoneNumberComponentSchema> = (
+  componentDefinition,
+  intl
+) => {
+  // TODO: handle `multiple`
+  const {key, validate = {}} = componentDefinition;
+  const {required, pattern} = validate;
+
+  // base phone number shape - a more narrow pattern can be specified in the form builder
+  let schema: z.ZodFirstPartySchemaTypes = z
+    .string()
+    .regex(/^[+0-9][- 0-9]+$/, {message: intl.formatMessage(PHONE_NUMBER_INVALID_MESSAGE)});
+
+  if (pattern) {
+    let normalizedPattern = pattern;
+    // Formio implicitly adds the ^ and $ markers to consider the whole value
+    if (!normalizedPattern.startsWith('^')) normalizedPattern = `^${normalizedPattern}`;
+    if (!normalizedPattern.endsWith('$')) normalizedPattern = `${normalizedPattern}$`;
+    schema = schema.regex(new RegExp(normalizedPattern));
+  }
+
+  if (required) {
+    schema = schema.min(1);
+  } else {
+    schema = schema.optional().or(z.literal(''));
+  }
+
+  return {[key]: schema};
+};
+
+export default getValidationSchema;

--- a/src/registry/registry.ts
+++ b/src/registry/registry.ts
@@ -3,6 +3,7 @@ import type {AnyComponentSchema} from '@open-formulieren/types';
 import BSN from './bsn';
 import Email from './email';
 import Fieldset from './fieldset';
+import PhoneNumber from './phoneNumber';
 import RadioField from './radio';
 import TextField from './textfield';
 import type {GetRegistryEntry, Registry, RegistryEntry} from './types';
@@ -18,6 +19,7 @@ const REGISTRY: Registry = {
   // basic
   textfield: TextField,
   email: Email,
+  phoneNumber: PhoneNumber,
   radio: RadioField,
   // special types
   bsn: BSN,


### PR DESCRIPTION
Partly closes #62

Ported over the code from the SDK, which now properly sets up the validator with a better (more accessible) valiation error message.