### PR TITLE
Control field validation behaviour

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Build library
         run: |
+          npm run compilemessages
           npm run build:typecheck
           npm run build
 

--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -3,6 +3,8 @@ import {fn} from '@storybook/test';
 import {Form, Formik} from 'formik';
 import {CSSProperties} from 'react';
 
+import RendererSettingsProvider from '../src/components/RendererSettingsProvider';
+
 /**
  * Wrap stories so that they are inside a container with the class name "utrecht-document", used
  * to wrap some 'page-global' styling.
@@ -50,3 +52,11 @@ export const withFormik: Decorator = (Story, context) => {
     </Formik>
   );
 };
+
+export const withRenderSettingsProvider: Decorator = (Story, {parameters}) => (
+  <RendererSettingsProvider
+    requiredFieldsWithAsterisk={parameters?.renderSettings?.requiredFieldsWithAsterisk ?? true}
+  >
+    <Story />
+  </RendererSettingsProvider>
+);

--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -2,6 +2,7 @@ import type {Decorator} from '@storybook/react';
 import {fn} from '@storybook/test';
 import {Form, Formik} from 'formik';
 import {CSSProperties} from 'react';
+import {toFormikValidationSchema} from 'zod-formik-adapter';
 
 import RendererSettingsProvider from '../src/components/RendererSettingsProvider';
 
@@ -34,6 +35,7 @@ export const withFormik: Decorator = (Story, context) => {
   const initialTouched = context.parameters?.formik?.initialTouched || {};
   const wrapForm = context.parameters?.formik?.wrapForm ?? true;
   const onSubmit = context.parameters?.formik?.onSubmit || fn();
+  const zodSchema = context.parameters?.formik?.zodSchema;
   return (
     <Formik
       initialValues={initialValues}
@@ -41,6 +43,9 @@ export const withFormik: Decorator = (Story, context) => {
       initialTouched={initialTouched}
       enableReinitialize
       onSubmit={async values => onSubmit(values)}
+      validateOnBlur={false}
+      validateOnChange={false}
+      validationSchema={zodSchema ? toFormikValidationSchema(zodSchema) : undefined}
     >
       {wrapForm ? (
         <Form id="storybook-withFormik-decorator-form" data-testid="storybook-formik-form">

--- a/src/components/FormioForm.stories.tsx
+++ b/src/components/FormioForm.stories.tsx
@@ -264,13 +264,17 @@ export const InitialErrorsRevalidation: Story = {
       expect(await canvas.findByText('External error for field 2')).toBeVisible();
     });
 
+    // NOTE - this doesn't work properly if the browser window is not focused. Chrome
+    // and Firefox appear not to dispatch the focus/blur events if another window on your
+    // device has focus.
     await step('Edit field 2', async () => {
       const input = canvas.getByLabelText('Field 2');
       await userEvent.type(input, 'invalid input');
       input.blur();
-
       expect(await canvas.findByText('Invalid')).toBeVisible();
       expect(canvas.queryByText('External error for field 2')).not.toBeInTheDocument();
+      // may not be removed
+      expect(canvas.getByText('External error for field 1')).toBeVisible();
     });
   },
 };

--- a/src/components/FormioForm.stories.tsx
+++ b/src/components/FormioForm.stories.tsx
@@ -229,3 +229,48 @@ export const WithErrors: Story = {
     expect(await canvas.findByText('Nested textfield error')).toBeVisible();
   },
 };
+
+// existing errors of untouched fields should not be cleared when another field is
+// touched
+export const InitialErrorsRevalidation: Story = {
+  args: {
+    components: [
+      {
+        id: 'component1',
+        type: 'textfield',
+        key: 'component1',
+        label: 'Field 1',
+      } satisfies TextFieldComponentSchema,
+      {
+        id: 'component2',
+        type: 'textfield',
+        key: 'component2',
+        label: 'Field 2',
+        validate: {
+          pattern: '[0-9]+',
+        },
+      } satisfies TextFieldComponentSchema,
+    ],
+    errors: {
+      component1: 'External error for field 1',
+      component2: 'External error for field 2',
+    },
+  },
+  play: async ({canvasElement, step}) => {
+    const canvas = within(canvasElement);
+
+    await step('Initial errors', async () => {
+      expect(await canvas.findByText('External error for field 1')).toBeVisible();
+      expect(await canvas.findByText('External error for field 2')).toBeVisible();
+    });
+
+    await step('Edit field 2', async () => {
+      const input = canvas.getByLabelText('Field 2');
+      await userEvent.type(input, 'invalid input');
+      input.blur();
+
+      expect(await canvas.findByText('Invalid')).toBeVisible();
+      expect(canvas.queryByText('External error for field 2')).not.toBeInTheDocument();
+    });
+  },
+};

--- a/src/components/forms/DateField/DateInputGroup.tsx
+++ b/src/components/forms/DateField/DateInputGroup.tsx
@@ -1,4 +1,4 @@
-import {useField} from 'formik';
+import {useField, useFormikContext} from 'formik';
 import {useEffect, useState} from 'react';
 
 import {InputGroup} from '@/components/forms/InputGroup';
@@ -67,6 +67,7 @@ const DateInputGroup: React.FC<DateInputGroupProps> = ({
   autoComplete,
   'aria-describedby': ariaDescribedBy,
 }) => {
+  const {validateField} = useFormikContext();
   // value is an ISO-8601 string _if_ a valid date was provided at some point.
   const [{value}, {error, touched}, {setTouched, setValue}] = useField<string>(name);
 
@@ -131,7 +132,12 @@ const DateInputGroup: React.FC<DateInputGroupProps> = ({
         day={day}
         isDisabled={isDisabled}
         onChange={onPartChange}
-        onBlur={() => setTouched(true)}
+        onBlur={async () => {
+          setTouched(true);
+          if (year && month && day) {
+            await validateField(name);
+          }
+        }}
         autoComplete={autoComplete}
       />
     </InputGroup>

--- a/src/components/forms/InputGroup/InputGroup.tsx
+++ b/src/components/forms/InputGroup/InputGroup.tsx
@@ -24,6 +24,7 @@ const InputGroup: React.FC<InputGroupProps> = ({
     invalid={isInvalid}
     className="utrecht-form-fieldset--openforms"
     aria-describedby={ariaDescribedBy}
+    data-testid="inputgroup-container"
   >
     <FieldsetLegend className="utrecht-form-field__label">
       <LabelContent isDisabled={isDisabled} isRequired={isRequired}>

--- a/src/components/forms/RadioField/RadioField.stories.ts
+++ b/src/components/forms/RadioField/RadioField.stories.ts
@@ -1,7 +1,7 @@
 import {Meta, StoryObj} from '@storybook/react';
 import {expect, userEvent, within} from '@storybook/test';
 
-import {withFormik} from '@/sb-decorators';
+import {withFormik, withRenderSettingsProvider} from '@/sb-decorators';
 
 import RadioField from './RadioField';
 
@@ -74,17 +74,17 @@ export const ValidationError: Story = {
   },
 };
 
-// export const NoAsterisks: Story = {
-//   name: 'No asterisk for required',
-//   decorators: [ConfigDecorator],
-//   parameters: {
-//     config: {
-//       requiredFieldsWithAsterisk: false,
-//     },
-//   },
-//   args: {
-//     name: 'test',
-//     label: 'Default required',
-//     isRequired: true,
-//   },
-// };
+export const NoAsterisks: Story = {
+  name: 'No asterisk for required',
+  decorators: [withRenderSettingsProvider],
+  parameters: {
+    renderSettings: {
+      requiredFieldsWithAsterisk: false,
+    },
+  },
+  args: {
+    name: 'test',
+    label: 'Default required',
+    isRequired: true,
+  },
+};

--- a/src/components/forms/RadioField/RadioField.stories.ts
+++ b/src/components/forms/RadioField/RadioField.stories.ts
@@ -1,5 +1,6 @@
 import {Meta, StoryObj} from '@storybook/react';
 import {expect, userEvent, within} from '@storybook/test';
+import {z} from 'zod';
 
 import {withFormik, withRenderSettingsProvider} from '@/sb-decorators';
 
@@ -86,5 +87,37 @@ export const NoAsterisks: Story = {
     name: 'test',
     label: 'Default required',
     isRequired: true,
+  },
+};
+
+export const ValidateOnBlur: Story = {
+  args: {
+    name: 'validateOnBlur',
+    label: 'Validate on blur',
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        validateOnBlur: '',
+      },
+      zodSchema: z.object({
+        validateOnBlur: z.any().refine(() => false, {message: 'Always invalid'}),
+      }),
+    },
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    const radioGroup = canvas.getByRole('radiogroup');
+
+    const input = await canvas.findByLabelText('Ziggy');
+    expect(radioGroup).not.toHaveAttribute('aria-invalid');
+
+    await userEvent.click(input);
+    expect(input).toHaveFocus();
+    expect(radioGroup).not.toHaveAttribute('aria-invalid');
+
+    input.blur();
+    expect(await canvas.findByText('Always invalid')).toBeVisible();
+    expect(radioGroup).toHaveAttribute('aria-invalid', 'true');
   },
 };

--- a/src/components/forms/RadioField/RadioOption.tsx
+++ b/src/components/forms/RadioField/RadioOption.tsx
@@ -1,5 +1,5 @@
 import {FormField, FormLabel, Paragraph, RadioButton} from '@utrecht/component-library-react';
-import {useField} from 'formik';
+import {useField, useFormikContext} from 'formik';
 
 export interface RadioOptionProps {
   name: string;
@@ -20,6 +20,7 @@ const RadioOption: React.FC<RadioOptionProps> = ({
   errorMessageId,
   isDisabled,
 }) => {
+  const {validateField} = useFormikContext();
   const [props] = useField({name, value, type: 'radio'});
 
   return (
@@ -29,6 +30,10 @@ const RadioOption: React.FC<RadioOptionProps> = ({
         id={`${id}-opt-${index}`}
         aria-describedby={errorMessageId}
         {...props}
+        onBlur={async e => {
+          props.onBlur(e);
+          await validateField(name);
+        }}
         value={value}
       />
       <Paragraph className="utrecht-form-field__label utrecht-form-field__label--radio">

--- a/src/components/forms/TextField/TextField.mdx
+++ b/src/components/forms/TextField/TextField.mdx
@@ -29,4 +29,4 @@ Validation errors are tracked in the Formik state and displayed if any are prese
 The backend can be configured to treat fields as required by default and instead mark optional
 fields explicitly, through the `ConfigContext`.
 
-{/* <Story of={TextFieldStories.NoAsterisks} /> */}
+<Story of={TextFieldStories.NoAsterisks} />

--- a/src/components/forms/TextField/TextField.stories.ts
+++ b/src/components/forms/TextField/TextField.stories.ts
@@ -1,7 +1,7 @@
 import {Meta, StoryObj} from '@storybook/react';
 import {expect, userEvent, within} from '@storybook/test';
 
-import {withFormik} from '@/sb-decorators';
+import {withFormik, withRenderSettingsProvider} from '@/sb-decorators';
 
 import TextField from './TextField';
 
@@ -68,17 +68,17 @@ export const ValidationError: Story = {
   },
 };
 
-// export const NoAsterisks = {
-//   name: 'No asterisk for required',
-//   decorators: [ConfigDecorator],
-//   parameters: {
-//     config: {
-//       requiredFieldsWithAsterisk: false,
-//     },
-//   },
-//   args: {
-//     name: 'test',
-//     label: 'Default required',
-//     isRequired: true,
-//   },
-// };
+export const NoAsterisks = {
+  name: 'No asterisk for required',
+  decorators: [withRenderSettingsProvider],
+  parameters: {
+    renderSettings: {
+      requiredFieldsWithAsterisk: false,
+    },
+  },
+  args: {
+    name: 'test',
+    label: 'Default required',
+    isRequired: true,
+  },
+};

--- a/src/components/forms/TextField/TextField.tsx
+++ b/src/components/forms/TextField/TextField.tsx
@@ -72,11 +72,8 @@ const TextField: React.FC<TextFieldProps & TextboxProps> = ({
         <Textbox
           {...props}
           onBlur={async e => {
-            console.log('onBlur');
             props.onBlur(e);
-            console.log('validating');
             await validateField(name);
-            console.log('validation done');
           }}
           className="utrecht-textbox--openforms"
           id={id}

--- a/src/components/forms/TextField/TextField.tsx
+++ b/src/components/forms/TextField/TextField.tsx
@@ -1,6 +1,6 @@
 import {FormField, Paragraph, Textbox} from '@utrecht/component-library-react';
 import type {TextboxProps} from '@utrecht/component-library-react/dist/Textbox';
-import {useField} from 'formik';
+import {useField, useFormikContext} from 'formik';
 import {useId} from 'react';
 
 import HelpText from '@/components/forms/HelpText';
@@ -56,6 +56,7 @@ const TextField: React.FC<TextFieldProps & TextboxProps> = ({
   placeholder,
   ...extraProps
 }) => {
+  const {validateField} = useFormikContext();
   const [props, {error = '', touched}] = useField({name, type: 'text'});
   const id = useId();
 
@@ -70,6 +71,13 @@ const TextField: React.FC<TextFieldProps & TextboxProps> = ({
       <Paragraph>
         <Textbox
           {...props}
+          onBlur={async e => {
+            console.log('onBlur');
+            props.onBlur(e);
+            console.log('validating');
+            await validateField(name);
+            console.log('validation done');
+          }}
           className="utrecht-textbox--openforms"
           id={id}
           disabled={isDisabled}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "strictBindCallApply": true,
     "strictNullChecks": true,
     "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
     "noErrorTruncation": true,
     "paths": {
       "@/*": ["./*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,6 @@
     },
     "skipLibCheck": true
   },
-  "include": ["src"],
+  "include": ["src/**/*", ".storybook/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Resolves #69 (mostly)

This switches the validation behaviour to be per-field (until you submit the form as a whole), and triggers validation on blur of a field.

TODO:

- [x] TextField (handles email, bsn, phone number, textfield)
- [x] Radio
- [x] DateField (input group)