### PR TITLE
Implement editgrid (repeating groups) - part 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           npm ci
           npm run compilemessages
-          npm run build-storybook --quiet
+          npm run build-storybook -- --stats-json --quiet
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,5 +1,4 @@
 import '@fortawesome/fontawesome-free/css/fontawesome.css';
-import '@fortawesome/fontawesome-free/css/regular.css';
 import '@fortawesome/fontawesome-free/css/solid.css';
 import '@open-formulieren/design-tokens/dist/index.css';
 import {Preview} from '@storybook/react';

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,3 +1,6 @@
+import '@fortawesome/fontawesome-free/css/fontawesome.css';
+import '@fortawesome/fontawesome-free/css/regular.css';
+import '@fortawesome/fontawesome-free/css/solid.css';
 import '@open-formulieren/design-tokens/dist/index.css';
 import {Preview} from '@storybook/react';
 import '@utrecht/components/dist/button/css/index.css';

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -3,7 +3,6 @@ import '@fortawesome/fontawesome-free/css/regular.css';
 import '@fortawesome/fontawesome-free/css/solid.css';
 import '@open-formulieren/design-tokens/dist/index.css';
 import {Preview} from '@storybook/react';
-import '@utrecht/components/dist/button/css/index.css';
 import '@utrecht/components/dist/document/css/index.css';
 
 import {utrechtDocumentDecorator} from './decorators';

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@babel/core": "^7.24.0",
         "@formatjs/cli": "^6.5.1",
+        "@fortawesome/fontawesome-free": "^6.7.2",
         "@open-formulieren/design-tokens": "^0.57.0",
         "@open-formulieren/types": "^0.38.0",
         "@storybook/addon-actions": "^8.6.2",
@@ -55,6 +56,7 @@
         "vitest": "^3.0.7"
       },
       "peerDependencies": {
+        "@fortawesome/fontawesome-free": ">= 6.4.0",
         "date-fns": "^4.0.0",
         "react": "^18.2.0",
         "react-intl": "^6.6.2 || ^7.0.0"
@@ -1171,6 +1173,15 @@
       "resolved": "https://registry.npmjs.org/@formio/vanilla-text-mask/-/vanilla-text-mask-5.1.1.tgz",
       "integrity": "sha512-7MhrbMypySPi7RLchg0ys7HnS3Wqddbq/btAijKB1nA94TE7AOOLhpZJWcNm3kOlX0Y3nHfoavj/HP7vsvF34Q==",
       "dev": true
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
+      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,8 @@
         "@trivago/prettier-plugin-sort-imports": "^5.2.0",
         "@types/react": "^18.2.65",
         "@types/webpack": "^5.28.5",
+        "@utrecht/button-group-css": "^1.4.0",
+        "@utrecht/button-group-react": "^1.0.0",
         "@utrecht/components": "^7.4.0",
         "@vitejs/plugin-react": "^4.3.4",
         "ajv": "^8.17.1",
@@ -3988,6 +3990,27 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true
+    },
+    "node_modules/@utrecht/button-group-css": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/button-group-css/-/button-group-css-1.4.0.tgz",
+      "integrity": "sha512-NV12LA6wh0IaBuqjVVD+dZUzl4Sk0aKKiO3qL0BT7XQJvygDRjJq3M5d2pI9BDMMOb9jgT6VuIARST0Qk6JuxQ==",
+      "dev": true
+    },
+    "node_modules/@utrecht/button-group-react": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/button-group-react/-/button-group-react-1.0.0.tgz",
+      "integrity": "sha512-0tjYrQvNrY92rmJDAgXDEpdhfYG7bFgfEfJNygofufHE/W0KvEC7Ndg384/IxihQbCuxinXBBAfI04VMxQGkoA==",
+      "dev": true,
+      "dependencies": {
+        "@utrecht/button-group-css": "1.4.0",
+        "clsx": "2.1.1"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "*",
+        "react": "18",
+        "react-dom": "18"
+      }
     },
     "node_modules/@utrecht/component-library-react": {
       "version": "1.0.0-alpha.353",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "homepage": "https://github.com/open-formulieren/formio-renderer#readme",
   "peerDependencies": {
+    "@fortawesome/fontawesome-free": ">= 6.4.0",
     "date-fns": "^4.0.0",
     "react": "^18.2.0",
     "react-intl": "^6.6.2 || ^7.0.0"
@@ -44,6 +45,7 @@
   "devDependencies": {
     "@babel/core": "^7.24.0",
     "@formatjs/cli": "^6.5.1",
+    "@fortawesome/fontawesome-free": "^6.7.2",
     "@open-formulieren/design-tokens": "^0.57.0",
     "@open-formulieren/types": "^0.38.0",
     "@storybook/addon-actions": "^8.6.2",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "@trivago/prettier-plugin-sort-imports": "^5.2.0",
     "@types/react": "^18.2.65",
     "@types/webpack": "^5.28.5",
+    "@utrecht/button-group-css": "^1.4.0",
+    "@utrecht/button-group-react": "^1.0.0",
     "@utrecht/components": "^7.4.0",
     "@vitejs/plugin-react": "^4.3.4",
     "ajv": "^8.17.1",

--- a/src/components/forms/EditGrid/EditGrid.mdx
+++ b/src/components/forms/EditGrid/EditGrid.mdx
@@ -1,0 +1,26 @@
+import {ArgTypes, Canvas, Meta} from '@storybook/blocks';
+
+import * as EditGridStories from './EditGrid.stories';
+import * as EditGridItemStories from './EditGridItem.stories';
+
+<Meta of={EditGridStories} />
+
+# Edit grid
+
+An edit grid allows editing arrays of items where each item has the same shape. The `EditGrid`
+component manages adding and removing individual items.
+
+The state is intended to be managed via Formik's
+[FieldArray](https://formik.org/docs/api/fieldarray).
+
+<Canvas of={EditGridStories.Default} />
+
+## Props
+
+**EditGrid**
+
+<ArgTypes of={EditGridStories} />
+
+**EditGridItem**
+
+<ArgTypes of={EditGridItemStories} />

--- a/src/components/forms/EditGrid/EditGrid.mdx
+++ b/src/components/forms/EditGrid/EditGrid.mdx
@@ -40,13 +40,7 @@ the `EditGrid` low-level component in your own Formik state.
 <EditGrid<MyItemData>
   name="myItems"
   emptyItem={{thisShape: 'is', typeChecked: true}}
-  items={[
-    {
-      children: <MyItemFormFields prefix="myItems.0" />,
-      heading: 'Item uno',
-      canRemove: true,
-    },
-  ]}
+  {...otherProps}
 />
 ```
 

--- a/src/components/forms/EditGrid/EditGrid.mdx
+++ b/src/components/forms/EditGrid/EditGrid.mdx
@@ -15,6 +15,42 @@ The state is intended to be managed via Formik's
 
 <Canvas of={EditGridStories.Default} />
 
+## Usage
+
+The edit grid component roughly follow Formio's `editgrid` type, but we have some additional
+flexibility.
+
+**Controlling extra items**
+
+The prop `emptyItem` controls what will be added to the form state when the "Add another" button is
+clicked. This means that you can actually (depending on form state) add different items each time,
+as long as the shape stays consistent.
+
+Pass `null` to disable adding extra rows/items.
+
+<Canvas of={EditGridStories.WithoutAddButton} />
+
+**Nested item type**
+
+The component is generic, so if you know upfront what the shape of the data is, you can pass that as
+a generic type argument for improved type checking. This can be particularly useful when rendering
+the `EditGrid` low-level component in your own Formik state.
+
+```tsx
+<EditGrid<MyItemData>
+  name="myItems"
+  emptyItem={{thisShape: 'is', typeChecked: true}}
+  items={[
+    {
+      children: <MyItemFormFields prefix="myItems.0" />,
+      heading: 'Item uno',
+      canEdit: true,
+      canRemove: true,
+    },
+  ]}
+/>
+```
+
 ## Props
 
 **EditGrid**
@@ -22,5 +58,7 @@ The state is intended to be managed via Formik's
 <ArgTypes of={EditGridStories} />
 
 **EditGridItem**
+
+This component is rendered automatically by `EditGrid` based on the `items` prop it receives.
 
 <ArgTypes of={EditGridItemStories} />

--- a/src/components/forms/EditGrid/EditGrid.mdx
+++ b/src/components/forms/EditGrid/EditGrid.mdx
@@ -44,12 +44,20 @@ the `EditGrid` low-level component in your own Formik state.
     {
       children: <MyItemFormFields prefix="myItems.0" />,
       heading: 'Item uno',
-      canEdit: true,
       canRemove: true,
     },
   ]}
 />
 ```
+
+**Isolation mode**
+
+To replicate Formio's editing behaviour, the isolation mode via `enableIsolation` is available. In
+this mode, edits to an item are only updated into the main form state after an explicit save action.
+This save button is _only_ available when `enableIsolation: true`, as it would otherwise be
+confusing.
+
+<Canvas of={EditGridStories.WithIsolation} />
 
 ## Props
 

--- a/src/components/forms/EditGrid/EditGrid.scss
+++ b/src/components/forms/EditGrid/EditGrid.scss
@@ -1,3 +1,4 @@
+@use '@utrecht/components/button';
 @use '@utrecht/components/button-group';
 @use '@utrecht/components/form-fieldset';
 

--- a/src/components/forms/EditGrid/EditGrid.scss
+++ b/src/components/forms/EditGrid/EditGrid.scss
@@ -1,5 +1,5 @@
+@use '@utrecht/button-group-css';
 @use '@utrecht/components/button';
-@use '@utrecht/components/button-group';
 @use '@utrecht/components/form-fieldset';
 
 @use '@/scss/bem';

--- a/src/components/forms/EditGrid/EditGrid.scss
+++ b/src/components/forms/EditGrid/EditGrid.scss
@@ -11,6 +11,12 @@
   flex-direction: column;
   gap: var(--of-editgrid-gap);
 
+  @include bem.element('container') {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
   @include bem.element('item') {
     // NL DS markup uses a field with nested fieldset element inside
     .utrecht-form-fieldset__fieldset {

--- a/src/components/forms/EditGrid/EditGrid.scss
+++ b/src/components/forms/EditGrid/EditGrid.scss
@@ -1,0 +1,63 @@
+@use '@utrecht/components/button-group';
+@use '@utrecht/components/form-fieldset';
+
+@use '@/scss/bem';
+
+.openforms-editgrid {
+  line-height: var(--of-editgrid-line-height, var(--utrecht-document-line-height));
+
+  display: flex;
+  flex-direction: column;
+  gap: var(--of-editgrid-gap);
+
+  @include bem.element('item') {
+    // NL DS markup uses a field with nested fieldset element inside
+    .utrecht-form-fieldset__fieldset {
+      display: flex;
+      flex-direction: column;
+      gap: var(--of-editgrid-item-gap);
+    }
+
+    border: var(--of-editgrid-item-border);
+    max-inline-size: var(--of-editgrid-item-max-inline-size);
+    padding-block-end: var(--of-editgrid-item-padding-block-end);
+    padding-block-start: var(--of-editgrid-item-padding-block-start);
+    padding-inline-end: var(--of-editgrid-item-padding-inline-end);
+    padding-inline-start: var(--of-editgrid-item-padding-inline-start);
+
+    // ensure borders are 'collapsed'
+    & + .openforms-editgrid__item {
+      border-block-start: none;
+    }
+  }
+
+  @include bem.element('item-heading') {
+    font-family: var(
+      --of-editgrid-item-heading-font-family,
+      var(--utrecht-form-fieldset-legend-font-family, var(--utrecht-document-font-family))
+    );
+    font-size: var(
+      --of-editgrid-item-heading-font-size,
+      var(--utrecht-form-fieldset-legend-font-size)
+    );
+    line-height: var(
+      --of-editgrid-item-heading-line-height,
+      var(--utrecht-form-fieldset-legend-line-height)
+    );
+    // display: contents was considered, but that doesn't allow specifying different
+    // margins/paddings at the bottom to create extra space :(
+    // legend element doesn't care about the fieldset itself having display: flex, so we
+    // must treat this specially
+    margin-block-end: var(--of-editgrid-item-heading-margin-block-end, var(--of-editgrid-item-gap));
+  }
+}
+
+.utrecht-button-group {
+  // A button group used in an edit grid item
+  @include bem.modifier('openforms-editgrid') {
+    // there currently does not exist a design token in the upstream component, and
+    // the alignment is also contextual, so we opt for an open-forms extension that
+    // can be tweaked with proprietary design tokens.
+    justify-content: var(--of-button-group-editgrid-justify-content, flex-end);
+  }
+}

--- a/src/components/forms/EditGrid/EditGrid.stories.tsx
+++ b/src/components/forms/EditGrid/EditGrid.stories.tsx
@@ -39,9 +39,18 @@ type Story = StoryObj<typeof EditGrid<ItemData>>;
 
 export const Default: Story = {};
 
-export const WithCustomAddButtonLabel: Story = {
+export const WithCustomButtonLabels: Story = {
   args: {
+    enableIsolation: true,
     addButtonLabel: 'Custom add button label',
+    saveItemLabel: 'Custom save item label',
+    removeItemLabel: 'Custom remove item label',
+  },
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', {name: 'Edit item 2'}));
   },
 };
 

--- a/src/components/forms/EditGrid/EditGrid.stories.tsx
+++ b/src/components/forms/EditGrid/EditGrid.stories.tsx
@@ -19,9 +19,9 @@ export default {
     emptyItem: {myField: ''},
     addButtonLabel: undefined,
     getItemHeading: (_, index) => `Item ${index + 1}`,
-    getItemBody: values => (
+    getItemBody: (values: ItemData) => (
       <code>
-        <pre>{JSON.stringify(values, null, 2)}</pre>
+        <pre style={{marginBlock: '0'}}>{JSON.stringify(values, null, 2)}</pre>
       </code>
     ),
     canRemoveItem: (_, index) => index % 2 === 1,
@@ -55,9 +55,9 @@ export const WithIsolation: Story = {
   args: {
     enableIsolation: true,
     getItemHeading: () => 'Isolation mode editing',
-    getItemBody: (values, index) => (
+    getItemBody: (values, index, {expanded}) => (
       <>
-        <TextField name="myField" label={`My field (${index + 1})`} />
+        {expanded && <TextField name="myField" label={`My field (${index + 1})`} />}
         <span>
           Raw data:
           <code>{JSON.stringify(values)}</code>
@@ -70,10 +70,12 @@ export const WithIsolation: Story = {
   play: async ({canvasElement, step}) => {
     const canvas = within(canvasElement);
 
+    await userEvent.click(canvas.getByRole('button', {name: 'Edit item 1'}));
     const field1 = await canvas.findByLabelText('My field (1)');
+    await userEvent.click(canvas.getByRole('button', {name: 'Edit item 2'}));
     const field2 = await canvas.findByLabelText('My field (2)');
 
-    await step('Initial data display', () => {
+    await step('Initial data display', async () => {
       expect(field1).toHaveDisplayValue('Item 1');
       expect(field2).toHaveDisplayValue('Item 2');
     });

--- a/src/components/forms/EditGrid/EditGrid.stories.tsx
+++ b/src/components/forms/EditGrid/EditGrid.stories.tsx
@@ -1,6 +1,4 @@
-import type {Decorator, Meta, StoryObj} from '@storybook/react';
-import {Paragraph} from '@utrecht/component-library-react';
-import {useFormikContext} from 'formik';
+import type {Meta, StoryObj} from '@storybook/react';
 
 import {TextField} from '@/components/forms';
 import {withFormik} from '@/sb-decorators';
@@ -11,48 +9,21 @@ interface ItemData {
   myField: string;
 }
 
-interface StoryValues {
-  items: ItemData[];
-}
-
-const withFormikValuesDisplay: Decorator = Story => {
-  const {values} = useFormikContext<StoryValues>();
-  return (
-    <>
-      <Story />
-      <div style={{marginBlockStart: '10px', background: '#ececec', padding: '10px'}}>
-        Formik state (values):
-        <code>
-          <pre>{JSON.stringify(values, null, 2)}</pre>
-        </code>
-      </div>
-    </>
-  );
-};
-
 export default {
   title: 'Internal API / Forms / EditGrid',
   component: EditGrid,
-  decorators: [withFormikValuesDisplay, withFormik],
+  decorators: [withFormik],
   args: {
     name: 'items',
-    items: [
-      {
-        heading: 'Item 1',
-        children: <Paragraph>First item</Paragraph>,
-        canRemove: false,
-      },
-      {
-        heading: 'Item 2',
-        children: <Paragraph>Second item</Paragraph>,
-        canRemove: true,
-      },
-    ],
     emptyItem: {myField: ''},
     addButtonLabel: undefined,
-  },
-  argTypes: {
-    items: {control: false},
+    getItemHeading: (_, index) => `Item ${index + 1}`,
+    getItemBody: values => (
+      <code>
+        <pre>{JSON.stringify(values, null, 2)}</pre>
+      </code>
+    ),
+    canRemoveItem: (_, index) => index % 2 === 1,
   },
   parameters: {
     formik: {
@@ -82,14 +53,10 @@ export const WithoutAddButton: Story = {
 export const WithIsolation: Story = {
   args: {
     enableIsolation: true,
-    items: [
-      {
-        heading: 'Isolation mode editing',
-        children: <TextField name="myField" label="My field" />,
-        canEdit: true,
-        canRemove: true,
-      },
-    ],
+    getItemHeading: () => 'Isolation mode editing',
+    getItemBody: () => <TextField name="myField" label="My field" />,
+    canRemoveItem: () => true,
+    canEditItem: () => true,
     emptyItem: {myField: ''},
   },
 };

--- a/src/components/forms/EditGrid/EditGrid.stories.tsx
+++ b/src/components/forms/EditGrid/EditGrid.stories.tsx
@@ -66,7 +66,6 @@ export const WithIsolation: Story = {
     ),
     canRemoveItem: () => true,
     canEditItem: () => true,
-    emptyItem: {myField: ''},
   },
   play: async ({canvasElement, step}) => {
     const canvas = within(canvasElement);
@@ -94,5 +93,30 @@ export const WithIsolation: Story = {
       expect(field1).toHaveDisplayValue('Item 1');
       expect(await canvas.findByText('{"myField":"Updated second item"}')).toBeVisible();
     });
+  },
+};
+
+export const InlineEditing: Story = {
+  args: {
+    enableIsolation: false,
+    getItemHeading: undefined,
+    getItemBody: (values, index) => (
+      <>
+        <TextField name={`items.${index}.myField`} label={`My field (${index + 1})`} />
+        <span>
+          Raw data:
+          <code>{JSON.stringify(values)}</code>
+        </span>
+      </>
+    ),
+    canEditItem: undefined,
+  },
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const field1 = await canvas.findByLabelText('My field (1)');
+    await userEvent.type(field1, ' updated');
+    expect(await canvas.findByText('{"myField":"Item 1 updated"}')).toBeVisible();
   },
 };

--- a/src/components/forms/EditGrid/EditGrid.stories.tsx
+++ b/src/components/forms/EditGrid/EditGrid.stories.tsx
@@ -1,0 +1,57 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {fn} from '@storybook/test';
+import {Paragraph, PrimaryActionButton} from '@utrecht/component-library-react';
+
+import EditGrid, {EditGridButtonGroup, EditGridItem} from '.';
+
+export default {
+  title: 'Internal API / Forms / EditGrid',
+  component: EditGrid,
+  args: {
+    onAddItem: fn(),
+
+    children: (
+      <>
+        <EditGridItem
+          heading="Item 1"
+          buttons={
+            <EditGridButtonGroup>
+              <PrimaryActionButton>A button</PrimaryActionButton>
+            </EditGridButtonGroup>
+          }
+        >
+          <Paragraph>First item</Paragraph>
+        </EditGridItem>
+        <EditGridItem
+          heading="Item 2"
+          buttons={
+            <EditGridButtonGroup>
+              <PrimaryActionButton>A button</PrimaryActionButton>
+            </EditGridButtonGroup>
+          }
+        >
+          <Paragraph>Second item</Paragraph>
+        </EditGridItem>
+      </>
+    ),
+  },
+  argTypes: {
+    children: {control: false},
+  },
+} satisfies Meta<typeof EditGrid>;
+
+type Story = StoryObj<typeof EditGrid>;
+
+export const Default: Story = {};
+
+export const WithCustomAddButtonLabel: Story = {
+  args: {
+    addButtonLabel: 'Custom add button label',
+  },
+};
+
+export const WithoutAddbutton: Story = {
+  args: {
+    onAddItem: undefined,
+  },
+};

--- a/src/components/forms/EditGrid/EditGrid.stories.tsx
+++ b/src/components/forms/EditGrid/EditGrid.stories.tsx
@@ -98,6 +98,34 @@ export const WithIsolation: Story = {
   },
 };
 
+export const AddingItemInIsolationMode: Story = {
+  args: {
+    enableIsolation: true,
+    getItemBody: (values, index, {expanded}) => (
+      <>
+        {expanded && <TextField name="myField" label={`My field (${index + 1})`} />}
+        <span>
+          Raw data:
+          <code>{JSON.stringify(values)}</code>
+        </span>
+      </>
+    ),
+    canRemoveItem: () => true,
+    emptyItem: {myField: 'new item'},
+  },
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', {name: 'Add another'}));
+    const editButtons = canvas.queryAllByRole('button', {name: /Edit item \d/});
+    expect(editButtons).toHaveLength(2); // the third one should not be visible because it must be initially expanded
+
+    const textfield = canvas.getByLabelText('My field (3)');
+    expect(textfield).toHaveDisplayValue('new item');
+  },
+};
+
 export const InlineEditing: Story = {
   args: {
     enableIsolation: false,

--- a/src/components/forms/EditGrid/EditGrid.stories.tsx
+++ b/src/components/forms/EditGrid/EditGrid.stories.tsx
@@ -1,42 +1,44 @@
 import type {Meta, StoryObj} from '@storybook/react';
-import {fn} from '@storybook/test';
-import {Paragraph, PrimaryActionButton} from '@utrecht/component-library-react';
+import {Paragraph} from '@utrecht/component-library-react';
 
-import EditGrid, {EditGridButtonGroup, EditGridItem} from '.';
+import {withFormik} from '@/sb-decorators';
+
+import EditGrid from '.';
 
 export default {
   title: 'Internal API / Forms / EditGrid',
   component: EditGrid,
+  decorators: [withFormik],
   args: {
-    onAddItem: fn(),
-
-    children: (
-      <>
-        <EditGridItem
-          heading="Item 1"
-          buttons={
-            <EditGridButtonGroup>
-              <PrimaryActionButton>A button</PrimaryActionButton>
-            </EditGridButtonGroup>
-          }
-        >
-          <Paragraph>First item</Paragraph>
-        </EditGridItem>
-        <EditGridItem
-          heading="Item 2"
-          buttons={
-            <EditGridButtonGroup>
-              <PrimaryActionButton>A button</PrimaryActionButton>
-            </EditGridButtonGroup>
-          }
-        >
-          <Paragraph>Second item</Paragraph>
-        </EditGridItem>
-      </>
-    ),
+    name: 'items',
+    items: [
+      {
+        heading: 'Item 1',
+        children: <Paragraph>First item</Paragraph>,
+        // TODO: should we just do inline edits, or keep the explicit edit/confirm?
+        canEdit: true,
+        canRemove: false,
+      },
+      {
+        heading: 'Item 2',
+        children: <Paragraph>Second item</Paragraph>,
+        // TODO: should we just do inline edits, or keep the explicit edit/confirm?
+        canEdit: true,
+        canRemove: true,
+      },
+    ],
+    emptyItem: {} as const,
+    addButtonLabel: undefined,
   },
   argTypes: {
-    children: {control: false},
+    items: {control: false},
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        items: [{}, {}],
+      },
+    },
   },
 } satisfies Meta<typeof EditGrid>;
 
@@ -50,8 +52,8 @@ export const WithCustomAddButtonLabel: Story = {
   },
 };
 
-export const WithoutAddbutton: Story = {
+export const WithoutAddButton: Story = {
   args: {
-    onAddItem: undefined,
+    emptyItem: null,
   },
 };

--- a/src/components/forms/EditGrid/EditGrid.stories.tsx
+++ b/src/components/forms/EditGrid/EditGrid.stories.tsx
@@ -1,33 +1,54 @@
-import type {Meta, StoryObj} from '@storybook/react';
+import type {Decorator, Meta, StoryObj} from '@storybook/react';
 import {Paragraph} from '@utrecht/component-library-react';
+import {useFormikContext} from 'formik';
 
+import {TextField} from '@/components/forms';
 import {withFormik} from '@/sb-decorators';
 
 import EditGrid from '.';
 
+interface ItemData {
+  myField: string;
+}
+
+interface StoryValues {
+  items: ItemData[];
+}
+
+const withFormikValuesDisplay: Decorator = Story => {
+  const {values} = useFormikContext<StoryValues>();
+  return (
+    <>
+      <Story />
+      <div style={{marginBlockStart: '10px', background: '#ececec', padding: '10px'}}>
+        Formik state (values):
+        <code>
+          <pre>{JSON.stringify(values, null, 2)}</pre>
+        </code>
+      </div>
+    </>
+  );
+};
+
 export default {
   title: 'Internal API / Forms / EditGrid',
   component: EditGrid,
-  decorators: [withFormik],
+  decorators: [withFormikValuesDisplay, withFormik],
   args: {
     name: 'items',
     items: [
       {
         heading: 'Item 1',
         children: <Paragraph>First item</Paragraph>,
-        // TODO: should we just do inline edits, or keep the explicit edit/confirm?
-        canEdit: true,
         canRemove: false,
       },
       {
         heading: 'Item 2',
         children: <Paragraph>Second item</Paragraph>,
-        // TODO: should we just do inline edits, or keep the explicit edit/confirm?
-        canEdit: true,
         canRemove: true,
       },
     ],
-    emptyItem: {} as const,
+    emptyItem: {myField: ''},
     addButtonLabel: undefined,
   },
   argTypes: {
@@ -36,13 +57,13 @@ export default {
   parameters: {
     formik: {
       initialValues: {
-        items: [{}, {}],
+        items: [{myField: 'Item 1'}, {myField: 'Item 2'}],
       },
     },
   },
-} satisfies Meta<typeof EditGrid>;
+} satisfies Meta<typeof EditGrid<ItemData>>;
 
-type Story = StoryObj<typeof EditGrid>;
+type Story = StoryObj<typeof EditGrid<ItemData>>;
 
 export const Default: Story = {};
 
@@ -55,5 +76,20 @@ export const WithCustomAddButtonLabel: Story = {
 export const WithoutAddButton: Story = {
   args: {
     emptyItem: null,
+  },
+};
+
+export const WithIsolation: Story = {
+  args: {
+    enableIsolation: true,
+    items: [
+      {
+        heading: 'Isolation mode editing',
+        children: <TextField name="myField" label="My field" />,
+        canEdit: true,
+        canRemove: true,
+      },
+    ],
+    emptyItem: {myField: ''},
   },
 };

--- a/src/components/forms/EditGrid/EditGrid.tsx
+++ b/src/components/forms/EditGrid/EditGrid.tsx
@@ -66,9 +66,6 @@ function EditGrid<T extends {[K in keyof T]: JSONValue} = JSONObject>({
 }: EditGridProps<T>) {
   const {getFieldProps} = useFormikContext();
   const {value: formikItems} = getFieldProps<T[]>(name);
-
-  console.log(formikItems);
-
   return (
     <FieldArray name={name} validateOnChange={false}>
       {arrayHelpers => (

--- a/src/components/forms/EditGrid/EditGrid.tsx
+++ b/src/components/forms/EditGrid/EditGrid.tsx
@@ -1,33 +1,87 @@
 import {ButtonGroup, PrimaryActionButton} from '@utrecht/component-library-react';
+import {FieldArray} from 'formik';
 import {FormattedMessage} from 'react-intl';
 
 import Icon from '@/components/icons';
+import type {JSONObject} from '@/types';
 
-export interface EditGridProps {
+import EditGridItem from './EditGridItem';
+
+/**
+ * A single item to display inside the EditGridItem container. It's the actual data
+ * contained in the editgrid value.
+ */
+export interface Item {
   children: React.ReactNode;
-  onAddItem: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  heading?: React.ReactNode;
+  canEdit?: boolean;
+  canRemove?: boolean;
+}
+
+export interface EditGridProps<T> {
+  /**
+   * Name of 'form field' in the Formio form data structure.
+   */
+  name: string;
+  /**
+   * Individual items, corresponding to the data in the array pointed to via `name`.
+   */
+  items: Item[];
+  /**
+   * Empty instance, will be added when the 'add another' button is clicked. If none is
+   * provided, adding items is not enabled.
+   */
+  emptyItem?: T | null;
+  /**
+   * Custom label for the 'add another' button.
+   */
   addButtonLabel?: string;
 }
 
-const EditGrid: React.FC<EditGridProps> = ({children, onAddItem, addButtonLabel = ''}) => (
-  <div className="openforms-editgrid">
-    <div>{children}</div>
+function EditGrid<T extends JSONObject = JSONObject>({
+  name,
+  items,
+  emptyItem = null,
+  addButtonLabel = '',
+}: EditGridProps<T>) {
+  return (
+    <FieldArray name={name} validateOnChange={false}>
+      {arrayHelpers => (
+        <div className="openforms-editgrid">
+          {/* Render each item wrapped in an EditGridItem */}
+          <div>
+            {items.map(({children: content, heading, canEdit, canRemove}, index) => (
+              <EditGridItem<T>
+                key={index}
+                heading={heading}
+                canEdit={canEdit}
+                canRemove={canRemove}
+                onRemove={() => arrayHelpers.remove(index)}
+                onReplace={(newValue: T) => arrayHelpers.replace(index, newValue)}
+              >
+                {content}
+              </EditGridItem>
+            ))}
+          </div>
 
-    {onAddItem && (
-      <ButtonGroup>
-        <PrimaryActionButton type="button" onClick={onAddItem}>
-          <Icon icon="add" />
-          &nbsp;
-          {addButtonLabel || (
-            <FormattedMessage
-              description="Edit grid add button, default label text"
-              defaultMessage="Add another"
-            />
+          {emptyItem && (
+            <ButtonGroup>
+              <PrimaryActionButton type="button" onClick={() => arrayHelpers.push(emptyItem)}>
+                <Icon icon="add" />
+                &nbsp;
+                {addButtonLabel || (
+                  <FormattedMessage
+                    description="Edit grid add button, default label text"
+                    defaultMessage="Add another"
+                  />
+                )}
+              </PrimaryActionButton>
+            </ButtonGroup>
           )}
-        </PrimaryActionButton>
-      </ButtonGroup>
-    )}
-  </div>
-);
+        </div>
+      )}
+    </FieldArray>
+  );
+}
 
 export default EditGrid;

--- a/src/components/forms/EditGrid/EditGrid.tsx
+++ b/src/components/forms/EditGrid/EditGrid.tsx
@@ -1,0 +1,31 @@
+import {ButtonGroup, PrimaryActionButton} from '@utrecht/component-library-react';
+import {FormattedMessage} from 'react-intl';
+
+export interface EditGridProps {
+  children: React.ReactNode;
+  onAddItem: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  addButtonLabel?: string;
+}
+
+const EditGrid: React.FC<EditGridProps> = ({children, onAddItem, addButtonLabel = ''}) => (
+  <div className="openforms-editgrid">
+    <div>{children}</div>
+
+    {onAddItem && (
+      <ButtonGroup>
+        <PrimaryActionButton type="button" onClick={onAddItem}>
+          {/* FIXME: support FAIcon */}
+          {/* <FAIcon icon="plus" />{' '} */}
+          {addButtonLabel || (
+            <FormattedMessage
+              description="Edit grid add button, default label text"
+              defaultMessage="Add another"
+            />
+          )}
+        </PrimaryActionButton>
+      </ButtonGroup>
+    )}
+  </div>
+);
+
+export default EditGrid;

--- a/src/components/forms/EditGrid/EditGrid.tsx
+++ b/src/components/forms/EditGrid/EditGrid.tsx
@@ -1,4 +1,5 @@
-import {ButtonGroup, PrimaryActionButton} from '@utrecht/component-library-react';
+import {ButtonGroup} from '@utrecht/button-group-react';
+import {PrimaryActionButton} from '@utrecht/component-library-react';
 import {FieldArray, useFormikContext} from 'formik';
 import {useState} from 'react';
 import {FormattedMessage} from 'react-intl';

--- a/src/components/forms/EditGrid/EditGrid.tsx
+++ b/src/components/forms/EditGrid/EditGrid.tsx
@@ -1,6 +1,8 @@
 import {ButtonGroup, PrimaryActionButton} from '@utrecht/component-library-react';
 import {FormattedMessage} from 'react-intl';
 
+import Icon from '@/components/icons';
+
 export interface EditGridProps {
   children: React.ReactNode;
   onAddItem: (event: React.MouseEvent<HTMLButtonElement>) => void;
@@ -14,8 +16,8 @@ const EditGrid: React.FC<EditGridProps> = ({children, onAddItem, addButtonLabel 
     {onAddItem && (
       <ButtonGroup>
         <PrimaryActionButton type="button" onClick={onAddItem}>
-          {/* FIXME: support FAIcon */}
-          {/* <FAIcon icon="plus" />{' '} */}
+          <Icon icon="add" />
+          &nbsp;
           {addButtonLabel || (
             <FormattedMessage
               description="Edit grid add button, default label text"

--- a/src/components/forms/EditGrid/EditGrid.tsx
+++ b/src/components/forms/EditGrid/EditGrid.tsx
@@ -26,6 +26,10 @@ interface EditGridBaseProps<T> {
    */
   canRemoveItem?: (values: T, index: number) => boolean;
   /**
+   * Custom label for the remove button.
+   */
+  removeItemLabel?: string;
+  /**
    * Empty instance, will be added when the 'add another' button is clicked. If `null` is
    * provided, adding items is disabled.
    */
@@ -39,6 +43,7 @@ interface EditGridBaseProps<T> {
 interface WithoutIsolation<T> {
   enableIsolation?: false;
   canEditItem?: never;
+  saveItemLabel?: never;
   /**
    * Callback to render the main content of a single item. Gets passed the item values and
    * index in the array of values.
@@ -56,6 +61,10 @@ interface WithIsolation<T> {
    */
   canEditItem?: (values: T, index: number) => boolean;
   /**
+   * Custom label for the save/confirm button.
+   */
+  saveItemLabel?: string;
+  /**
    * Callback to render the main content of a single item. Gets passed the item values and
    * index in the array of values.
    *
@@ -70,6 +79,7 @@ function EditGrid<T extends {[K in keyof T]: JSONValue} = JSONObject>({
   name,
   getItemHeading,
   canRemoveItem,
+  removeItemLabel = '',
   emptyItem = null,
   addButtonLabel = '',
   ...props
@@ -93,8 +103,10 @@ function EditGrid<T extends {[K in keyof T]: JSONValue} = JSONObject>({
                   enableIsolation
                   data={values}
                   canEdit={props.canEditItem?.(values, index) ?? true}
-                  onReplace={(newValue: T) => arrayHelpers.replace(index, newValue)}
+                  saveLabel={props.saveItemLabel}
+                  onChange={(newValue: T) => arrayHelpers.replace(index, newValue)}
                   canRemove={canRemoveItem?.(values, index) ?? true}
+                  removeLabel={removeItemLabel}
                   onRemove={() => arrayHelpers.remove(index)}
                   initiallyExpanded={indexToAutoExpand === index}
                 />
@@ -105,6 +117,7 @@ function EditGrid<T extends {[K in keyof T]: JSONValue} = JSONObject>({
                   getBody={opts => props.getItemBody(values, index, opts)}
                   heading={getItemHeading?.(values, index)}
                   canRemove={canRemoveItem?.(values, index) ?? true}
+                  removeLabel={removeItemLabel}
                   onRemove={() => arrayHelpers.remove(index)}
                 />
               )

--- a/src/components/forms/EditGrid/EditGrid.tsx
+++ b/src/components/forms/EditGrid/EditGrid.tsx
@@ -1,5 +1,6 @@
 import {ButtonGroup, PrimaryActionButton} from '@utrecht/component-library-react';
 import {FieldArray, useFormikContext} from 'formik';
+import {useState} from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import Icon from '@/components/icons';
@@ -74,6 +75,7 @@ function EditGrid<T extends {[K in keyof T]: JSONValue} = JSONObject>({
 }: EditGridProps<T>) {
   const {getFieldProps} = useFormikContext();
   const {value: formikItems} = getFieldProps<T[]>(name);
+  const [indexToAutoExpand, setIndexToAutoExpand] = useState<number | null>(null);
   return (
     <FieldArray name={name} validateOnChange={false}>
       {arrayHelpers => (
@@ -93,6 +95,7 @@ function EditGrid<T extends {[K in keyof T]: JSONValue} = JSONObject>({
                   onReplace={(newValue: T) => arrayHelpers.replace(index, newValue)}
                   canRemove={canRemoveItem?.(values, index) ?? true}
                   onRemove={() => arrayHelpers.remove(index)}
+                  initiallyExpanded={indexToAutoExpand === index}
                 />
               ) : (
                 <EditGridItem<T>
@@ -109,7 +112,13 @@ function EditGrid<T extends {[K in keyof T]: JSONValue} = JSONObject>({
 
           {emptyItem && (
             <ButtonGroup>
-              <PrimaryActionButton type="button" onClick={() => arrayHelpers.push(emptyItem)}>
+              <PrimaryActionButton
+                type="button"
+                onClick={() => {
+                  setIndexToAutoExpand(formikItems.length);
+                  arrayHelpers.push(emptyItem);
+                }}
+              >
                 <Icon icon="add" />
                 &nbsp;
                 {addButtonLabel || (

--- a/src/components/forms/EditGrid/EditGrid.tsx
+++ b/src/components/forms/EditGrid/EditGrid.tsx
@@ -92,7 +92,7 @@ function EditGrid<T extends {[K in keyof T]: JSONValue} = JSONObject>({
       {arrayHelpers => (
         <div className="openforms-editgrid">
           {/* Render each item wrapped in an EditGridItem */}
-          <div>
+          <ol className="openforms-editgrid__container">
             {formikItems.map((values, index) =>
               props.enableIsolation ? (
                 <EditGridItem<T>
@@ -122,7 +122,7 @@ function EditGrid<T extends {[K in keyof T]: JSONValue} = JSONObject>({
                 />
               )
             )}
-          </div>
+          </ol>
 
           {emptyItem && (
             <ButtonGroup>

--- a/src/components/forms/EditGrid/EditGridButtonGroup.tsx
+++ b/src/components/forms/EditGrid/EditGridButtonGroup.tsx
@@ -1,4 +1,4 @@
-import {ButtonGroup} from '@utrecht/component-library-react';
+import {ButtonGroup} from '@utrecht/button-group-react';
 
 export interface EditGridButtonGroupProps {
   children: React.ReactNode;

--- a/src/components/forms/EditGrid/EditGridButtonGroup.tsx
+++ b/src/components/forms/EditGrid/EditGridButtonGroup.tsx
@@ -1,0 +1,11 @@
+import {ButtonGroup} from '@utrecht/component-library-react';
+
+export interface EditGridButtonGroupProps {
+  children: React.ReactNode;
+}
+
+const EditGridButtonGroup: React.FC<EditGridButtonGroupProps> = ({children}) => (
+  <ButtonGroup className="utrecht-button-group--openforms-editgrid">{children}</ButtonGroup>
+);
+
+export default EditGridButtonGroup;

--- a/src/components/forms/EditGrid/EditGridItem.stories.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.stories.tsx
@@ -1,11 +1,8 @@
 import type {Meta, StoryObj} from '@storybook/react';
-import {
-  Paragraph,
-  PrimaryActionButton,
-  SecondaryActionButton,
-} from '@utrecht/component-library-react';
+import {fn} from '@storybook/test';
+import {Paragraph} from '@utrecht/component-library-react';
 
-import {EditGridButtonGroup, EditGridItem} from '.';
+import {EditGridItem} from '.';
 
 export default {
   title: 'Internal API / Forms / EditGrid / EditGridItem',
@@ -13,16 +10,15 @@ export default {
   args: {
     children: <Paragraph>Any body content, typically a summary or form fields.</Paragraph>,
     heading: 'A heading for the item',
-    buttons: (
-      <EditGridButtonGroup>
-        <PrimaryActionButton type="button">Primary</PrimaryActionButton>
-        <SecondaryActionButton hint="danger">Danger</SecondaryActionButton>
-      </EditGridButtonGroup>
-    ),
+    canEdit: undefined,
+    saveLabel: undefined,
+    onReplace: fn(),
+    canRemove: undefined,
+    removeLabel: undefined,
+    onRemove: fn(),
   },
   argTypes: {
     children: {control: false},
-    buttons: {control: false},
   },
 } satisfies Meta<typeof EditGridItem>;
 
@@ -33,5 +29,24 @@ export const WithHeading: Story = {};
 export const WithoutHeading: Story = {
   args: {
     heading: undefined,
+  },
+};
+
+export const CanEdit: Story = {
+  args: {
+    canEdit: true,
+  },
+};
+
+export const CanRemove: Story = {
+  args: {
+    canRemove: true,
+  },
+};
+
+export const CanEditAndRemove: Story = {
+  args: {
+    canEdit: true,
+    canRemove: true,
   },
 };

--- a/src/components/forms/EditGrid/EditGridItem.stories.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.stories.tsx
@@ -18,7 +18,7 @@ export default {
   ],
   args: {
     index: 0,
-    children: <Paragraph>Any body content, typically a summary or form fields.</Paragraph>,
+    getBody: () => <Paragraph>Any body content, typically a summary or form fields.</Paragraph>,
     heading: 'A heading for the item',
     canEdit: undefined,
     saveLabel: undefined,
@@ -26,9 +26,6 @@ export default {
     canRemove: undefined,
     removeLabel: undefined,
     onRemove: fn(),
-  },
-  argTypes: {
-    children: {control: false},
   },
 } satisfies Meta<typeof EditGridItem>;
 
@@ -56,11 +53,14 @@ export const IsolatedMode: Story = {
     },
     canEdit: true,
     canRemove: false,
-    children: <TextField name="topLevelKey" label="Top level key" />,
+    getBody: ({expanded}) =>
+      expanded ? <TextField name="topLevelKey" label="Top level key" /> : 'A preview body',
   },
 
   play: async ({canvasElement, args}) => {
     const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', {name: 'Edit item 1'}));
 
     const textfield = canvas.getByLabelText('Top level key');
     await userEvent.clear(textfield);
@@ -74,12 +74,7 @@ export const IsolatedMode: Story = {
 
 export const IsolatedModeCanRemove: Story = {
   args: {
-    enableIsolation: true,
-    data: {
-      topLevelKey: 'initial',
-    },
-    canEdit: true,
+    ...IsolatedMode.args,
     canRemove: true,
-    children: <TextField name="topLevelKey" label="Top level key" />,
   },
 };

--- a/src/components/forms/EditGrid/EditGridItem.stories.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.stories.tsx
@@ -22,7 +22,7 @@ export default {
     heading: 'A heading for the item',
     canEdit: undefined,
     saveLabel: undefined,
-    onReplace: fn(),
+    onChange: fn(),
     canRemove: undefined,
     removeLabel: undefined,
     onRemove: fn(),
@@ -68,7 +68,7 @@ export const IsolatedMode: Story = {
     expect(textfield).toHaveDisplayValue('updated value');
 
     await userEvent.click(canvas.getByRole('button', {name: 'Save'}));
-    expect(args.onReplace).toHaveBeenCalledWith({topLevelKey: 'updated value'});
+    expect(args.onChange).toHaveBeenCalledWith({topLevelKey: 'updated value'});
   },
 };
 

--- a/src/components/forms/EditGrid/EditGridItem.stories.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.stories.tsx
@@ -1,0 +1,37 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {
+  Paragraph,
+  PrimaryActionButton,
+  SecondaryActionButton,
+} from '@utrecht/component-library-react';
+
+import {EditGridButtonGroup, EditGridItem} from '.';
+
+export default {
+  title: 'Internal API / Forms / EditGrid / EditGridItem',
+  component: EditGridItem,
+  args: {
+    children: <Paragraph>Any body content, typically a summary or form fields.</Paragraph>,
+    heading: 'A heading for the item',
+    buttons: (
+      <EditGridButtonGroup>
+        <PrimaryActionButton type="button">Primary</PrimaryActionButton>
+        <SecondaryActionButton hint="danger">Danger</SecondaryActionButton>
+      </EditGridButtonGroup>
+    ),
+  },
+  argTypes: {
+    children: {control: false},
+    buttons: {control: false},
+  },
+} satisfies Meta<typeof EditGridItem>;
+
+type Story = StoryObj<typeof EditGridItem>;
+
+export const WithHeading: Story = {};
+
+export const WithoutHeading: Story = {
+  args: {
+    heading: undefined,
+  },
+};

--- a/src/components/forms/EditGrid/EditGridItem.stories.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.stories.tsx
@@ -17,6 +17,7 @@ export default {
     ),
   ],
   args: {
+    index: 0,
     children: <Paragraph>Any body content, typically a summary or form fields.</Paragraph>,
     heading: 'A heading for the item',
     canEdit: undefined,

--- a/src/components/forms/EditGrid/EditGridItem.stories.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.stories.tsx
@@ -1,12 +1,21 @@
 import type {Meta, StoryObj} from '@storybook/react';
-import {fn} from '@storybook/test';
+import {expect, fn, userEvent, within} from '@storybook/test';
 import {Paragraph} from '@utrecht/component-library-react';
+
+import {TextField} from '@/components/forms';
 
 import {EditGridItem} from '.';
 
 export default {
   title: 'Internal API / Forms / EditGrid / EditGridItem',
   component: EditGridItem,
+  decorators: [
+    Story => (
+      <div className="openforms-editgrid">
+        <Story />
+      </div>
+    ),
+  ],
   args: {
     children: <Paragraph>Any body content, typically a summary or form fields.</Paragraph>,
     heading: 'A heading for the item',
@@ -48,5 +57,29 @@ export const CanEditAndRemove: Story = {
   args: {
     canEdit: true,
     canRemove: true,
+  },
+};
+
+export const IsolatedMode: Story = {
+  args: {
+    enableIsolation: true,
+    data: {
+      topLevelKey: 'initial',
+    },
+    canEdit: true,
+    canRemove: false,
+    children: <TextField name="topLevelKey" label="Top level key" />,
+  },
+
+  play: async ({canvasElement, args}) => {
+    const canvas = within(canvasElement);
+
+    const textfield = canvas.getByLabelText('Top level key');
+    expect(textfield).toHaveDisplayValue('initial');
+    await userEvent.clear(textfield);
+    await userEvent.type(textfield, 'updated value');
+
+    await userEvent.click(canvas.getByRole('button', {name: 'Save'}));
+    expect(args.onReplace).toHaveBeenCalledWith({topLevelKey: 'updated value'});
   },
 };

--- a/src/components/forms/EditGrid/EditGridItem.stories.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.stories.tsx
@@ -41,21 +41,8 @@ export const WithoutHeading: Story = {
   },
 };
 
-export const CanEdit: Story = {
-  args: {
-    canEdit: true,
-  },
-};
-
 export const CanRemove: Story = {
   args: {
-    canRemove: true,
-  },
-};
-
-export const CanEditAndRemove: Story = {
-  args: {
-    canEdit: true,
     canRemove: true,
   },
 };
@@ -75,11 +62,23 @@ export const IsolatedMode: Story = {
     const canvas = within(canvasElement);
 
     const textfield = canvas.getByLabelText('Top level key');
-    expect(textfield).toHaveDisplayValue('initial');
     await userEvent.clear(textfield);
     await userEvent.type(textfield, 'updated value');
+    expect(textfield).toHaveDisplayValue('updated value');
 
     await userEvent.click(canvas.getByRole('button', {name: 'Save'}));
     expect(args.onReplace).toHaveBeenCalledWith({topLevelKey: 'updated value'});
+  },
+};
+
+export const IsolatedModeCanRemove: Story = {
+  args: {
+    enableIsolation: true,
+    data: {
+      topLevelKey: 'initial',
+    },
+    canEdit: true,
+    canRemove: true,
+    children: <TextField name="topLevelKey" label="Top level key" />,
   },
 };

--- a/src/components/forms/EditGrid/EditGridItem.stories.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.stories.tsx
@@ -12,7 +12,9 @@ export default {
   decorators: [
     Story => (
       <div className="openforms-editgrid">
-        <Story />
+        <ol className="openforms-editgrid__container">
+          <Story />
+        </ol>
       </div>
     ),
   ],

--- a/src/components/forms/EditGrid/EditGridItem.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.tsx
@@ -10,6 +10,7 @@ import EditGridButtonGroup from './EditGridButtonGroup';
 import {IsolationModeButtons} from './EditGridItemButtons';
 
 interface EditGridItemBaseProps {
+  index: number;
   /**
    * Body of the item, such as the form fields to edit or the read-only preview of the
    * item.
@@ -75,6 +76,7 @@ export type EditGridItemProps<T> = EditGridItemBaseProps & (WithoutIsolation | W
 // TODO: track open/collapsed state and adapt the buttons accordingly
 
 function EditGridItem<T extends JSONObject = JSONObject>({
+  index,
   children,
   heading,
   canRemove,
@@ -105,6 +107,9 @@ function EditGridItem<T extends JSONObject = JSONObject>({
           initialValues={props.data}
           initialErrors={{}}
           initialTouched={false ? setNestedObjectValues(errors, true) : undefined}
+          // when removing items, the order changes, so we must re-render to display the
+          // correct data
+          enableReinitialize
           validateOnChange={false}
           validateOnBlur={false}
           validationSchema={false ? toFormikValidationSchema(zodSchema) : undefined}

--- a/src/components/forms/EditGrid/EditGridItem.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.tsx
@@ -1,0 +1,30 @@
+import {Fieldset, FieldsetLegend} from '@utrecht/component-library-react';
+
+export interface EditGridItemProps {
+  /**
+   * Body of the item, such as the form fields to edit or the read-only preview of the
+   * item.
+   */
+  children: React.ReactNode;
+  /**
+   * Heading for the item, will be rendered as a fieldset legend unless no value is
+   * provided.
+   */
+  heading?: React.ReactNode;
+  /**
+   * Control buttons for the item, e.g. to remove, edit or save it.
+   */
+  buttons?: React.ReactNode;
+}
+
+const EditGridItem: React.FC<EditGridItemProps> = ({children, heading, buttons}) => (
+  <Fieldset className="openforms-editgrid__item">
+    {heading && (
+      <FieldsetLegend className="openforms-editgrid__item-heading">{heading}</FieldsetLegend>
+    )}
+    {children}
+    {buttons}
+  </Fieldset>
+);
+
+export default EditGridItem;

--- a/src/components/forms/EditGrid/EditGridItem.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.tsx
@@ -165,7 +165,19 @@ function EditGridItem<T extends JSONObject = JSONObject>({
                 </SecondaryActionButton>
 
                 {canRemove && (
-                  <PrimaryActionButton hint="danger" onClick={onRemove}>
+                  <PrimaryActionButton
+                    hint="danger"
+                    onClick={onRemove}
+                    aria-label={intl.formatMessage(
+                      {
+                        description:
+                          'Accessible remove icon/button label for item inside edit grid',
+                        defaultMessage: 'Remove item {index}',
+                      },
+                      {index: index + 1}
+                    )}
+                    aria-describedby={heading ? headingId : undefined}
+                  >
                     <Icon icon="remove" />
                   </PrimaryActionButton>
                 )}

--- a/src/components/forms/EditGrid/EditGridItem.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.tsx
@@ -1,12 +1,15 @@
 import {Fieldset, FieldsetLegend} from '@utrecht/component-library-react';
 import {PrimaryActionButton} from '@utrecht/component-library-react';
+import {Formik, setNestedObjectValues} from 'formik';
 import {FormattedMessage} from 'react-intl';
+import {toFormikValidationSchema} from 'zod-formik-adapter';
 
 import type {JSONObject} from '@/types';
 
 import EditGridButtonGroup from './EditGridButtonGroup';
+import {IsolationModeButtons} from './EditGridItemButtons';
 
-export interface EditGridItemProps<T> {
+interface EditGridItemBaseProps {
   /**
    * Body of the item, such as the form fields to edit or the read-only preview of the
    * item.
@@ -17,19 +20,6 @@ export interface EditGridItemProps<T> {
    * provided.
    */
   heading?: React.ReactNode;
-
-  /**
-   * If true, edit control button(s) are rendered.
-   */
-  canEdit?: boolean;
-  /**
-   * Custom label for the save/confirm button.
-   */
-  saveLabel?: string;
-  /**
-   * Callback invoked when confirming the item changes.
-   */
-  onReplace: (newValue: T) => void;
 
   /**
    * If true, remove button(s) are rendered.
@@ -45,17 +35,52 @@ export interface EditGridItemProps<T> {
   onRemove: () => void;
 }
 
+interface WithoutIsolation {
+  enableIsolation?: false;
+  data?: never;
+  canEdit?: never;
+  saveLabel?: never;
+  onReplace?: never;
+}
+
+interface WithIsolation<T> {
+  /**
+   * In isolation mode, fields of an item can be edited without them affecting the
+   * entire form state. Only when the edits are saved/confirmed, is the parent form
+   * state updated.
+   */
+  enableIsolation: true;
+  /**
+   * Existing item data, passed to the underlying Formik component as initial state.
+   * Note that this is only accepted as *initial* data and changes in props do not change
+   * the form field values.
+   */
+  data: T;
+  /**
+   * If true, edit control button(s) are rendered.
+   */
+  canEdit?: boolean;
+  /**
+   * Custom label for the save/confirm button.
+   */
+  saveLabel?: string;
+  /**
+   * Callback invoked when confirming the item changes.
+   */
+  onReplace: (newValue: T) => void;
+}
+
+export type EditGridItemProps<T> = EditGridItemBaseProps & (WithoutIsolation | WithIsolation<T>);
+
 // TODO: track open/collapsed state and adapt the buttons accordingly
 
 function EditGridItem<T extends JSONObject = JSONObject>({
   children,
   heading,
-  canEdit,
-  saveLabel,
-  onReplace,
   canRemove,
   removeLabel,
   onRemove,
+  ...props
 }: EditGridItemProps<T>) {
   return (
     <Fieldset className="openforms-editgrid__item">
@@ -63,31 +88,54 @@ function EditGridItem<T extends JSONObject = JSONObject>({
         <FieldsetLegend className="openforms-editgrid__item-heading">{heading}</FieldsetLegend>
       )}
 
-      {children}
+      {/*
+        In isolation mode, set up a separate Formik context that requires user interaction
+        before it's committed to the parent state. In non-isolation mode, the caller needs
+        to provide the form fields with their deeply nested field names so the state is
+        updated directly, so then we render as-is.
+      */}
 
-      {(canEdit || canRemove) && (
-        <EditGridButtonGroup>
-          {canEdit && (
-            <PrimaryActionButton type="button" onClick={() => onReplace('TODO')}>
-              {saveLabel || (
-                <FormattedMessage
-                  description="Edit grid item default save button label"
-                  defaultMessage="Save"
-                />
-              )}
-            </PrimaryActionButton>
-          )}
+      {props.enableIsolation && props.canEdit ? (
+        // We apply the same Formik rendering philosophy as in FormioForm.tsx w/r to initial
+        // values, errors, touched state and the validation behaviour (validate individual fields, on blur)
+        <Formik<T>
+          initialValues={props.data}
+          initialErrors={{}}
+          initialTouched={false ? setNestedObjectValues(errors, true) : undefined}
+          validateOnChange={false}
+          validateOnBlur={false}
+          validationSchema={false ? toFormikValidationSchema(zodSchema) : undefined}
+          // TODO: trigger submit from primary button - perhaps Formik should wrap the entire thing?
+          onSubmit={async values => {
+            if (props.canEdit) props.onReplace(values);
+          }}
+        >
+          <>
+            {children}
+            <IsolationModeButtons
+              saveLabel={props.saveLabel}
+              canRemove={Boolean(canRemove)}
+              onRemove={onRemove}
+              removeLabel={removeLabel}
+            />
+          </>
+        </Formik>
+      ) : (
+        <>
+          {children}
           {canRemove && (
-            <PrimaryActionButton hint="danger" onClick={onRemove}>
-              {removeLabel || (
-                <FormattedMessage
-                  description="Edit grid item default remove button label"
-                  defaultMessage="Remove"
-                />
-              )}
-            </PrimaryActionButton>
+            <EditGridButtonGroup>
+              <PrimaryActionButton hint="danger" onClick={onRemove}>
+                {removeLabel || (
+                  <FormattedMessage
+                    description="Edit grid item default remove button label"
+                    defaultMessage="Remove"
+                  />
+                )}
+              </PrimaryActionButton>
+            </EditGridButtonGroup>
           )}
-        </EditGridButtonGroup>
+        </>
       )}
     </Fieldset>
   );

--- a/src/components/forms/EditGrid/EditGridItem.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.tsx
@@ -82,6 +82,9 @@ function EditGridItem<T extends JSONObject = JSONObject>({
   onRemove,
   ...props
 }: EditGridItemProps<T>) {
+  // TODO
+  const errors: any = {};
+  const zodSchema: any = null;
   return (
     <Fieldset className="openforms-editgrid__item">
       {heading && (

--- a/src/components/forms/EditGrid/EditGridItem.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.tsx
@@ -44,6 +44,7 @@ interface WithoutIsolation {
   canEdit?: never;
   saveLabel?: never;
   onReplace?: never;
+  initiallyExpanded?: false;
 }
 
 interface WithIsolation<T> {
@@ -76,6 +77,10 @@ interface WithIsolation<T> {
    * Callback invoked when confirming the item changes.
    */
   onReplace: (newValue: T) => void;
+  /**
+   * Set to `true` for newly added items so that the user can start editing directly.
+   */
+  initiallyExpanded?: boolean;
 }
 
 export type EditGridItemProps<T> = EditGridItemBaseProps & (WithoutIsolation | WithIsolation<T>);
@@ -88,10 +93,11 @@ function EditGridItem<T extends JSONObject = JSONObject>({
   canRemove,
   removeLabel,
   onRemove,
+  initiallyExpanded = false,
   ...props
 }: EditGridItemProps<T>) {
   const intl = useIntl();
-  const [expanded, setExpanded] = useState<boolean>(false);
+  const [expanded, setExpanded] = useState<boolean>(initiallyExpanded);
   const headingId = useId();
 
   // TODO

--- a/src/components/forms/EditGrid/EditGridItem.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.tsx
@@ -1,6 +1,12 @@
 import {Fieldset, FieldsetLegend} from '@utrecht/component-library-react';
+import {PrimaryActionButton} from '@utrecht/component-library-react';
+import {FormattedMessage} from 'react-intl';
 
-export interface EditGridItemProps {
+import type {JSONObject} from '@/types';
+
+import EditGridButtonGroup from './EditGridButtonGroup';
+
+export interface EditGridItemProps<T> {
   /**
    * Body of the item, such as the form fields to edit or the read-only preview of the
    * item.
@@ -11,20 +17,80 @@ export interface EditGridItemProps {
    * provided.
    */
   heading?: React.ReactNode;
+
   /**
-   * Control buttons for the item, e.g. to remove, edit or save it.
+   * If true, edit control button(s) are rendered.
    */
-  buttons?: React.ReactNode;
+  canEdit?: boolean;
+  /**
+   * Custom label for the save/confirm button.
+   */
+  saveLabel?: string;
+  /**
+   * Callback invoked when confirming the item changes.
+   */
+  onReplace: (newValue: T) => void;
+
+  /**
+   * If true, remove button(s) are rendered.
+   */
+  canRemove?: boolean;
+  /**
+   * Custom label for the remove button.
+   */
+  removeLabel?: string;
+  /**
+   * Callback invoked when deleting the item.
+   */
+  onRemove: () => void;
 }
 
-const EditGridItem: React.FC<EditGridItemProps> = ({children, heading, buttons}) => (
-  <Fieldset className="openforms-editgrid__item">
-    {heading && (
-      <FieldsetLegend className="openforms-editgrid__item-heading">{heading}</FieldsetLegend>
-    )}
-    {children}
-    {buttons}
-  </Fieldset>
-);
+// TODO: track open/collapsed state and adapt the buttons accordingly
+
+function EditGridItem<T extends JSONObject = JSONObject>({
+  children,
+  heading,
+  canEdit,
+  saveLabel,
+  onReplace,
+  canRemove,
+  removeLabel,
+  onRemove,
+}: EditGridItemProps<T>) {
+  return (
+    <Fieldset className="openforms-editgrid__item">
+      {heading && (
+        <FieldsetLegend className="openforms-editgrid__item-heading">{heading}</FieldsetLegend>
+      )}
+
+      {children}
+
+      {(canEdit || canRemove) && (
+        <EditGridButtonGroup>
+          {canEdit && (
+            <PrimaryActionButton type="button" onClick={() => onReplace('TODO')}>
+              {saveLabel || (
+                <FormattedMessage
+                  description="Edit grid item default save button label"
+                  defaultMessage="Save"
+                />
+              )}
+            </PrimaryActionButton>
+          )}
+          {canRemove && (
+            <PrimaryActionButton hint="danger" onClick={onRemove}>
+              {removeLabel || (
+                <FormattedMessage
+                  description="Edit grid item default remove button label"
+                  defaultMessage="Remove"
+                />
+              )}
+            </PrimaryActionButton>
+          )}
+        </EditGridButtonGroup>
+      )}
+    </Fieldset>
+  );
+}
 
 export default EditGridItem;

--- a/src/components/forms/EditGrid/EditGridItem.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.tsx
@@ -1,9 +1,11 @@
-import {Fieldset, FieldsetLegend} from '@utrecht/component-library-react';
+import {Fieldset, FieldsetLegend, SecondaryActionButton} from '@utrecht/component-library-react';
 import {PrimaryActionButton} from '@utrecht/component-library-react';
 import {Formik, setNestedObjectValues} from 'formik';
-import {FormattedMessage} from 'react-intl';
+import {useId, useState} from 'react';
+import {FormattedMessage, useIntl} from 'react-intl';
 import {toFormikValidationSchema} from 'zod-formik-adapter';
 
+import Icon from '@/components/icons';
 import type {JSONObject} from '@/types';
 
 import EditGridButtonGroup from './EditGridButtonGroup';
@@ -84,13 +86,19 @@ function EditGridItem<T extends JSONObject = JSONObject>({
   onRemove,
   ...props
 }: EditGridItemProps<T>) {
+  const intl = useIntl();
+  const [expanded, setExpanded] = useState<boolean>(false);
+  const headingId = useId();
+
   // TODO
   const errors: any = {};
   const zodSchema: any = null;
   return (
     <Fieldset className="openforms-editgrid__item">
       {heading && (
-        <FieldsetLegend className="openforms-editgrid__item-heading">{heading}</FieldsetLegend>
+        <FieldsetLegend className="openforms-editgrid__item-heading" id={headingId}>
+          {heading}
+        </FieldsetLegend>
       )}
 
       {/*
@@ -116,16 +124,43 @@ function EditGridItem<T extends JSONObject = JSONObject>({
           // TODO: trigger submit from primary button - perhaps Formik should wrap the entire thing?
           onSubmit={async values => {
             if (props.canEdit) props.onReplace(values);
+            setExpanded(false);
           }}
         >
           <>
             {children}
-            <IsolationModeButtons
-              saveLabel={props.saveLabel}
-              canRemove={Boolean(canRemove)}
-              onRemove={onRemove}
-              removeLabel={removeLabel}
-            />
+
+            {expanded ? (
+              <IsolationModeButtons
+                saveLabel={props.saveLabel}
+                canRemove={Boolean(canRemove)}
+                onRemove={onRemove}
+                removeLabel={removeLabel}
+              />
+            ) : (
+              <EditGridButtonGroup>
+                <SecondaryActionButton
+                  type="button"
+                  onClick={() => setExpanded(true)}
+                  aria-label={intl.formatMessage(
+                    {
+                      description: 'Accessible edit icon/button label for item inside edit grid',
+                      defaultMessage: 'Edit item {index}',
+                    },
+                    {index: index + 1}
+                  )}
+                  aria-describedby={heading ? headingId : undefined}
+                >
+                  <Icon icon="edit" />
+                </SecondaryActionButton>
+
+                {canRemove && (
+                  <PrimaryActionButton hint="danger" onClick={onRemove}>
+                    <Icon icon="remove" />
+                  </PrimaryActionButton>
+                )}
+              </EditGridButtonGroup>
+            )}
           </>
         </Formik>
       ) : (

--- a/src/components/forms/EditGrid/EditGridItem.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.tsx
@@ -14,11 +14,6 @@ import {IsolationModeButtons} from './EditGridItemButtons';
 interface EditGridItemBaseProps {
   index: number;
   /**
-   * Body of the item, such as the form fields to edit or the read-only preview of the
-   * item.
-   */
-  children: React.ReactNode;
-  /**
    * Heading for the item, will be rendered as a fieldset legend unless no value is
    * provided.
    */
@@ -40,6 +35,11 @@ interface EditGridItemBaseProps {
 
 interface WithoutIsolation {
   enableIsolation?: false;
+  /**
+   * Callback to render the main content of a single item. Gets passed options representing
+   * the current UI state.
+   */
+  getBody: (opts: {expanded: false}) => React.ReactNode;
   data?: never;
   canEdit?: never;
   saveLabel?: never;
@@ -60,6 +60,11 @@ interface WithIsolation<T> {
    */
   data: T;
   /**
+   * Callback to render the main content of a single item. Gets passed options representing
+   * the current UI state.
+   */
+  getBody: (opts: {expanded: boolean}) => React.ReactNode;
+  /**
    * If true, edit control button(s) are rendered.
    */
   canEdit?: boolean;
@@ -79,7 +84,6 @@ export type EditGridItemProps<T> = EditGridItemBaseProps & (WithoutIsolation | W
 
 function EditGridItem<T extends JSONObject = JSONObject>({
   index,
-  children,
   heading,
   canRemove,
   removeLabel,
@@ -128,7 +132,7 @@ function EditGridItem<T extends JSONObject = JSONObject>({
           }}
         >
           <>
-            {children}
+            {props.getBody({expanded})}
 
             {expanded ? (
               <IsolationModeButtons
@@ -165,7 +169,7 @@ function EditGridItem<T extends JSONObject = JSONObject>({
         </Formik>
       ) : (
         <>
-          {children}
+          {props.getBody({expanded: false})}
           {canRemove && (
             <EditGridButtonGroup>
               <PrimaryActionButton hint="danger" onClick={onRemove}>

--- a/src/components/forms/EditGrid/EditGridItem.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.tsx
@@ -110,95 +110,97 @@ function EditGridItem<T extends JSONObject = JSONObject>({
   const errors: any = {};
   const zodSchema: any = null;
   return (
-    <Fieldset className="openforms-editgrid__item">
-      {heading && (
-        <FieldsetLegend className="openforms-editgrid__item-heading" id={headingId}>
-          {heading}
-        </FieldsetLegend>
-      )}
+    <li className="openforms-editgrid__item">
+      <Fieldset>
+        {heading && (
+          <FieldsetLegend className="openforms-editgrid__item-heading" id={headingId}>
+            {heading}
+          </FieldsetLegend>
+        )}
 
-      {/*
+        {/*
         In isolation mode, set up a separate Formik context that requires user interaction
         before it's committed to the parent state. In non-isolation mode, the caller needs
         to provide the form fields with their deeply nested field names so the state is
         updated directly, so then we render as-is.
       */}
 
-      {props.enableIsolation && props.canEdit ? (
-        // We apply the same Formik rendering philosophy as in FormioForm.tsx w/r to initial
-        // values, errors, touched state and the validation behaviour (validate individual fields, on blur)
-        <Formik<T>
-          initialValues={props.data}
-          initialErrors={{}}
-          initialTouched={false ? setNestedObjectValues(errors, true) : undefined}
-          // when removing items, the order changes, so we must re-render to display the
-          // correct data
-          enableReinitialize
-          validateOnChange={false}
-          validateOnBlur={false}
-          validationSchema={false ? toFormikValidationSchema(zodSchema) : undefined}
-          onSubmit={async values => {
-            if (props.canEdit) props.onChange(values);
-            setExpanded(false);
-          }}
-        >
-          <>
-            {props.getBody({expanded})}
+        {props.enableIsolation && props.canEdit ? (
+          // We apply the same Formik rendering philosophy as in FormioForm.tsx w/r to initial
+          // values, errors, touched state and the validation behaviour (validate individual fields, on blur)
+          <Formik<T>
+            initialValues={props.data}
+            initialErrors={{}}
+            initialTouched={false ? setNestedObjectValues(errors, true) : undefined}
+            // when removing items, the order changes, so we must re-render to display the
+            // correct data
+            enableReinitialize
+            validateOnChange={false}
+            validateOnBlur={false}
+            validationSchema={false ? toFormikValidationSchema(zodSchema) : undefined}
+            onSubmit={async values => {
+              if (props.canEdit) props.onChange(values);
+              setExpanded(false);
+            }}
+          >
+            <>
+              {props.getBody({expanded})}
 
-            {expanded ? (
-              <IsolationModeButtons
-                saveLabel={props.saveLabel}
-                canRemove={Boolean(canRemove)}
-                onRemove={onRemove}
-                removeLabel={removeLabel}
-                aria-describedby={heading ? headingId : undefined}
-              />
-            ) : (
-              <EditGridButtonGroup>
-                <SecondaryActionButton
-                  type="button"
-                  onClick={() => setExpanded(true)}
-                  aria-label={intl.formatMessage(
-                    {
-                      description: 'Accessible edit icon/button label for item inside edit grid',
-                      defaultMessage: 'Edit item {index}',
-                    },
-                    {index: index + 1}
-                  )}
+              {expanded ? (
+                <IsolationModeButtons
+                  saveLabel={props.saveLabel}
+                  canRemove={Boolean(canRemove)}
+                  onRemove={onRemove}
+                  removeLabel={removeLabel}
                   aria-describedby={heading ? headingId : undefined}
-                >
-                  <Icon icon="edit" />
-                </SecondaryActionButton>
-
-                {canRemove && (
-                  <PrimaryActionButton
-                    hint="danger"
-                    onClick={onRemove}
-                    aria-label={accessibleRemoveButtonLabel}
+                />
+              ) : (
+                <EditGridButtonGroup>
+                  <SecondaryActionButton
+                    type="button"
+                    onClick={() => setExpanded(true)}
+                    aria-label={intl.formatMessage(
+                      {
+                        description: 'Accessible edit icon/button label for item inside edit grid',
+                        defaultMessage: 'Edit item {index}',
+                      },
+                      {index: index + 1}
+                    )}
                     aria-describedby={heading ? headingId : undefined}
                   >
-                    <Icon icon="remove" />
-                  </PrimaryActionButton>
-                )}
+                    <Icon icon="edit" />
+                  </SecondaryActionButton>
+
+                  {canRemove && (
+                    <PrimaryActionButton
+                      hint="danger"
+                      onClick={onRemove}
+                      aria-label={accessibleRemoveButtonLabel}
+                      aria-describedby={heading ? headingId : undefined}
+                    >
+                      <Icon icon="remove" />
+                    </PrimaryActionButton>
+                  )}
+                </EditGridButtonGroup>
+              )}
+            </>
+          </Formik>
+        ) : (
+          <>
+            {props.getBody({expanded: false})}
+            {canRemove && (
+              <EditGridButtonGroup>
+                <RemoveButton
+                  label={removeLabel}
+                  onClick={onRemove}
+                  aria-describedby={heading ? headingId : undefined}
+                />
               </EditGridButtonGroup>
             )}
           </>
-        </Formik>
-      ) : (
-        <>
-          {props.getBody({expanded: false})}
-          {canRemove && (
-            <EditGridButtonGroup>
-              <RemoveButton
-                label={removeLabel}
-                onClick={onRemove}
-                aria-describedby={heading ? headingId : undefined}
-              />
-            </EditGridButtonGroup>
-          )}
-        </>
-      )}
-    </Fieldset>
+        )}
+      </Fieldset>
+    </li>
   );
 }
 

--- a/src/components/forms/EditGrid/EditGridItemButtons.tsx
+++ b/src/components/forms/EditGrid/EditGridItemButtons.tsx
@@ -7,10 +7,16 @@ import EditGridButtonGroup from './EditGridButtonGroup';
 export interface SaveButtonProps {
   label?: React.ReactNode;
   onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  // accessibility
+  ['aria-describedby']: string | undefined;
 }
 
-const SaveButton: React.FC<SaveButtonProps> = ({label, onClick}) => (
-  <PrimaryActionButton type="button" onClick={onClick}>
+const SaveButton: React.FC<SaveButtonProps> = ({
+  label,
+  onClick,
+  ['aria-describedby']: ariaDescribedBy,
+}) => (
+  <PrimaryActionButton type="button" onClick={onClick} aria-describedby={ariaDescribedBy}>
     {label || (
       <FormattedMessage
         description="Edit grid item default save button label"
@@ -23,10 +29,16 @@ const SaveButton: React.FC<SaveButtonProps> = ({label, onClick}) => (
 export interface RemoveButtonProps {
   label?: React.ReactNode;
   onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  // accessibility
+  ['aria-describedby']: string | undefined;
 }
 
-const RemoveButton: React.FC<RemoveButtonProps> = ({label, onClick}) => (
-  <PrimaryActionButton hint="danger" onClick={onClick}>
+const RemoveButton: React.FC<RemoveButtonProps> = ({
+  label,
+  onClick,
+  ['aria-describedby']: ariaDescribedBy,
+}) => (
+  <PrimaryActionButton hint="danger" onClick={onClick} aria-describedby={ariaDescribedBy}>
     {label || (
       <FormattedMessage
         description="Edit grid item default remove button label"
@@ -43,6 +55,8 @@ export interface IsolationModeButtonsProps {
   canRemove: boolean;
   removeLabel?: React.ReactNode;
   onRemove: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  // accessibility
+  ['aria-describedby']: string | undefined;
 }
 
 /**
@@ -61,6 +75,7 @@ const IsolationModeButtons: React.FC<IsolationModeButtonsProps> = ({
   canRemove,
   removeLabel,
   onRemove,
+  ['aria-describedby']: ariaDescribedBy,
 }) => {
   const {submitForm} = useFormikContext<unknown>();
   return (
@@ -71,8 +86,11 @@ const IsolationModeButtons: React.FC<IsolationModeButtonsProps> = ({
           e.preventDefault();
           await submitForm();
         }}
+        aria-describedby={ariaDescribedBy}
       />
-      {canRemove && <RemoveButton label={removeLabel} onClick={onRemove} />}
+      {canRemove && (
+        <RemoveButton label={removeLabel} onClick={onRemove} aria-describedby={ariaDescribedBy} />
+      )}
     </EditGridButtonGroup>
   );
 };

--- a/src/components/forms/EditGrid/EditGridItemButtons.tsx
+++ b/src/components/forms/EditGrid/EditGridItemButtons.tsx
@@ -1,0 +1,80 @@
+import {PrimaryActionButton} from '@utrecht/component-library-react';
+import {useFormikContext} from 'formik';
+import {FormattedMessage} from 'react-intl';
+
+import EditGridButtonGroup from './EditGridButtonGroup';
+
+export interface SaveButtonProps {
+  label?: React.ReactNode;
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+const SaveButton: React.FC<SaveButtonProps> = ({label, onClick}) => (
+  <PrimaryActionButton type="button" onClick={onClick}>
+    {label || (
+      <FormattedMessage
+        description="Edit grid item default save button label"
+        defaultMessage="Save"
+      />
+    )}
+  </PrimaryActionButton>
+);
+
+export interface RemoveButtonProps {
+  label?: React.ReactNode;
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+const RemoveButton: React.FC<RemoveButtonProps> = ({label, onClick}) => (
+  <PrimaryActionButton hint="danger" onClick={onClick}>
+    {label || (
+      <FormattedMessage
+        description="Edit grid item default remove button label"
+        defaultMessage="Remove"
+      />
+    )}
+  </PrimaryActionButton>
+);
+
+export interface IsolationModeButtonsProps {
+  // Saving
+  saveLabel?: React.ReactNode;
+  // Removing
+  canRemove: boolean;
+  removeLabel?: React.ReactNode;
+  onRemove: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+/**
+ * Button row rendered when an edit grid item is in isolation & editing mode.
+ *
+ * Isolation mode guarantees us that a formik context is available _for the inner item_.
+ * Likely there's also a Formik context for the entire form as a whole, but that's the
+ * wrong one.
+ *
+ * The `canEdit` is not relevant here anymore - this component shouldn't be rendered
+ * in the first place if editing is not enable (as it doesn't allow toggling) into
+ * edit state.
+ */
+const IsolationModeButtons: React.FC<IsolationModeButtonsProps> = ({
+  saveLabel,
+  canRemove,
+  removeLabel,
+  onRemove,
+}) => {
+  const {submitForm} = useFormikContext<unknown>();
+  return (
+    <EditGridButtonGroup>
+      <SaveButton
+        label={saveLabel}
+        onClick={async e => {
+          e.preventDefault();
+          await submitForm();
+        }}
+      />
+      {canRemove && <RemoveButton label={removeLabel} onClick={onRemove} />}
+    </EditGridButtonGroup>
+  );
+};
+
+export {SaveButton, RemoveButton, IsolationModeButtons};

--- a/src/components/forms/EditGrid/index.ts
+++ b/src/components/forms/EditGrid/index.ts
@@ -1,0 +1,7 @@
+import EditGrid from './EditGrid';
+import './EditGrid.scss';
+
+export {default as EditGridButtonGroup} from './EditGridButtonGroup';
+export {default as EditGridItem} from './EditGridItem';
+
+export default EditGrid;

--- a/src/components/icons/FontAwesome.tsx
+++ b/src/components/icons/FontAwesome.tsx
@@ -1,0 +1,50 @@
+import clsx from 'clsx';
+
+import type {RendererIcon} from './types';
+
+/**
+ * Mapping of semantic icon names to the font-awesome icon name.
+ */
+const FA_MAP: Record<RendererIcon, string> = {
+  add: 'plus',
+  edit: 'edit',
+  remove: 'trash-can',
+};
+
+interface FontAwesomeSolidIconProps {
+  /**
+   * Optional extra class name to apply to the icon element.
+   */
+  className?: string;
+  icon: RendererIcon;
+  /**
+   * Specify whether the icon should be hidden from screenreaders or not. Hidden by default.
+   */
+  'aria-hidden'?: boolean | 'true' | 'false';
+  /**
+   * Accessible icon label in case the icon is not hidden to screen readers.
+   */
+  'aria-label'?: string;
+  'aria-describedby'?: string;
+}
+
+const FontAwesomeSolidIcon: React.FC<FontAwesomeSolidIconProps> = ({
+  className: extraClassName,
+  ['aria-hidden']: ariaHidden = true,
+  ['aria-label']: ariaLabel,
+  ['aria-describedby']: ariaDescribedBy,
+  icon,
+}) => {
+  const iconName = FA_MAP[icon] ?? icon;
+  const className = clsx('fa-solid', `fa-${iconName}`, extraClassName);
+  return (
+    <i
+      className={className}
+      aria-hidden={ariaHidden}
+      aria-label={ariaLabel || undefined}
+      aria-describedby={ariaDescribedBy || undefined}
+    />
+  );
+};
+
+export {FontAwesomeSolidIcon};

--- a/src/components/icons/Icon.mdx
+++ b/src/components/icons/Icon.mdx
@@ -14,10 +14,20 @@ The project that uses the formio renderer and its icons is responsible for prope
 Awesome font assets - we only produce markup with the correct accesibility attributes and class
 names to display the icons correctly.
 
-## Example
-
-<Canvas of={IconStories.Add} />
-
 ## Props
 
 <ArgTypes />
+
+## Supported icons
+
+**Add**
+
+<Canvas of={IconStories.Add} />
+
+**Edit**
+
+<Canvas of={IconStories.Edit} />
+
+**Remove**
+
+<Canvas of={IconStories.Remove} />

--- a/src/components/icons/Icon.mdx
+++ b/src/components/icons/Icon.mdx
@@ -1,0 +1,23 @@
+import {ArgTypes, Canvas, Meta} from '@storybook/blocks';
+
+import * as IconStories from './Icon.stories';
+
+<Meta of={IconStories} />
+
+# Icons
+
+Icons are essential in user interfaces. At the time of writing, the Formio renderer only supports
+Font Awesome icons, but we organise the code so that future support of other icon libraries is not
+out of the question.
+
+The project that uses the formio renderer and its icons is responsible for properly loading the Font
+Awesome font assets - we only produce markup with the correct accesibility attributes and class
+names to display the icons correctly.
+
+## Example
+
+<Canvas of={IconStories.Add} />
+
+## Props
+
+<ArgTypes />

--- a/src/components/icons/Icon.stories.ts
+++ b/src/components/icons/Icon.stories.ts
@@ -6,8 +6,6 @@ export default {
   title: 'Internal API / Icons',
   component: Icon,
   args: {
-    // @ts-expect-error
-    icon: 'question',
     className: undefined,
     'aria-hidden': true,
     'aria-label': undefined,
@@ -22,9 +20,14 @@ export const Add: Story = {
   },
 };
 
-export const ArbitraryIconValue: Story = {
+export const Edit: Story = {
   args: {
-    // @ts-expect-error
-    icon: 'otter',
+    icon: 'edit',
+  },
+};
+
+export const Remove: Story = {
+  args: {
+    icon: 'remove',
   },
 };

--- a/src/components/icons/Icon.stories.ts
+++ b/src/components/icons/Icon.stories.ts
@@ -1,0 +1,30 @@
+import {Meta, StoryObj} from '@storybook/react';
+
+import Icon from './Icon';
+
+export default {
+  title: 'Internal API / Icons',
+  component: Icon,
+  args: {
+    // @ts-expect-error
+    icon: 'question',
+    className: undefined,
+    'aria-hidden': true,
+    'aria-label': undefined,
+  },
+} satisfies Meta<typeof Icon>;
+
+type Story = StoryObj<typeof Icon>;
+
+export const Add: Story = {
+  args: {
+    icon: 'add',
+  },
+};
+
+export const ArbitraryIconValue: Story = {
+  args: {
+    // @ts-expect-error
+    icon: 'otter',
+  },
+};

--- a/src/components/icons/Icon.tsx
+++ b/src/components/icons/Icon.tsx
@@ -1,0 +1,51 @@
+import clsx from 'clsx';
+
+// Map 'semantic' icons to their font-awesome icon name. This is a layer of indirection
+// allowing strong typing for the supported icons & future support for alternative icon
+// libraries.
+export const FA_MAP = {
+  add: 'plus',
+};
+
+// TODO: if/when we support pluggable icon libraries, this probably needs to become
+// generic.
+export interface IconProps {
+  library?: 'font-awesome';
+  /**
+   * Icon to display.
+   */
+  icon: keyof typeof FA_MAP;
+
+  // These options should probably be shared irrelevant the icon library used.
+
+  /**
+   * Optional extra class name to apply to the icon element.
+   */
+  className?: string;
+  /**
+   * Specify whether the icon should be hidden from screenreaders or not. Hidden by default.
+   */
+  'aria-hidden'?: boolean | 'true' | 'false';
+  /**
+   * Accessible icon label in case the icon is not hidden to screen readers.
+   */
+  'aria-label'?: string;
+}
+
+const Icon: React.FC<IconProps> = ({
+  library = 'font-awesome',
+  className: extraClassName,
+  ['aria-hidden']: ariaHidden = true,
+  ['aria-label']: ariaLabel,
+  icon,
+}) => {
+  if (library !== 'font-awesome') {
+    throw new Error(`Unsupported icon library: ${library}.`);
+  }
+
+  const iconName = FA_MAP[icon] ?? icon;
+  const className = clsx('fa', 'fas', 'fa-icon', `fa-${iconName}`, extraClassName);
+  return <i className={className} aria-hidden={ariaHidden} aria-label={ariaLabel || undefined} />;
+};
+
+export default Icon;

--- a/src/components/icons/Icon.tsx
+++ b/src/components/icons/Icon.tsx
@@ -5,6 +5,8 @@ import clsx from 'clsx';
 // libraries.
 export const FA_MAP = {
   add: 'plus',
+  edit: 'edit',
+  remove: 'trash-can',
 };
 
 // TODO: if/when we support pluggable icon libraries, this probably needs to become
@@ -30,6 +32,7 @@ export interface IconProps {
    * Accessible icon label in case the icon is not hidden to screen readers.
    */
   'aria-label'?: string;
+  'aria-describedby'?: string;
 }
 
 const Icon: React.FC<IconProps> = ({
@@ -37,6 +40,7 @@ const Icon: React.FC<IconProps> = ({
   className: extraClassName,
   ['aria-hidden']: ariaHidden = true,
   ['aria-label']: ariaLabel,
+  ['aria-describedby']: ariaDescribedBy,
   icon,
 }) => {
   if (library !== 'font-awesome') {
@@ -45,7 +49,14 @@ const Icon: React.FC<IconProps> = ({
 
   const iconName = FA_MAP[icon] ?? icon;
   const className = clsx('fa', 'fas', 'fa-icon', `fa-${iconName}`, extraClassName);
-  return <i className={className} aria-hidden={ariaHidden} aria-label={ariaLabel || undefined} />;
+  return (
+    <i
+      className={className}
+      aria-hidden={ariaHidden}
+      aria-label={ariaLabel || undefined}
+      aria-describedby={ariaDescribedBy || undefined}
+    />
+  );
 };
 
 export default Icon;

--- a/src/components/icons/Icon.tsx
+++ b/src/components/icons/Icon.tsx
@@ -1,13 +1,5 @@
-import clsx from 'clsx';
-
-// Map 'semantic' icons to their font-awesome icon name. This is a layer of indirection
-// allowing strong typing for the supported icons & future support for alternative icon
-// libraries.
-export const FA_MAP = {
-  add: 'plus',
-  edit: 'edit',
-  remove: 'trash-can',
-};
+import {FontAwesomeSolidIcon} from './FontAwesome';
+import type {RendererIcon} from './types';
 
 // TODO: if/when we support pluggable icon libraries, this probably needs to become
 // generic.
@@ -16,7 +8,7 @@ export interface IconProps {
   /**
    * Icon to display.
    */
-  icon: keyof typeof FA_MAP;
+  icon: RendererIcon;
 
   // These options should probably be shared irrelevant the icon library used.
 
@@ -37,26 +29,28 @@ export interface IconProps {
 
 const Icon: React.FC<IconProps> = ({
   library = 'font-awesome',
-  className: extraClassName,
+  className,
   ['aria-hidden']: ariaHidden = true,
   ['aria-label']: ariaLabel,
   ['aria-describedby']: ariaDescribedBy,
   icon,
 }) => {
-  if (library !== 'font-awesome') {
-    throw new Error(`Unsupported icon library: ${library}.`);
+  switch (library) {
+    case 'font-awesome': {
+      return (
+        <FontAwesomeSolidIcon
+          icon={icon}
+          className={className}
+          aria-hidden={ariaHidden}
+          aria-label={ariaLabel}
+          aria-describedby={ariaDescribedBy}
+        />
+      );
+    }
+    default: {
+      throw new Error(`Unsupported icon library: ${library}.`);
+    }
   }
-
-  const iconName = FA_MAP[icon] ?? icon;
-  const className = clsx('fa', 'fas', 'fa-icon', `fa-${iconName}`, extraClassName);
-  return (
-    <i
-      className={className}
-      aria-hidden={ariaHidden}
-      aria-label={ariaLabel || undefined}
-      aria-describedby={ariaDescribedBy || undefined}
-    />
-  );
 };
 
 export default Icon;

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -1,0 +1,3 @@
+import Icon from './Icon';
+
+export default Icon;

--- a/src/components/icons/types.ts
+++ b/src/components/icons/types.ts
@@ -1,0 +1,5 @@
+/**
+ * The semantic names of icons that we use. Each icon library alternative should provide
+ * an actual icon for each union member.
+ */
+export type RendererIcon = 'add' | 'edit' | 'remove';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "ES2021",
     "jsx": "react-jsx",
     "declaration": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Closes #36 (partly)

- Added Formik primitives and markup/styling for edit grid, mostly ported from the SDK
- Added an initial abstraction for icons, anticipating custom icon libraries in the future
- Ensure that form values are managed via Formik concepts, making it easy to provide the content for a single item
- Added the distinction between isolated vs. inline editing (former is Formio editgrid, latter is our appointment flow)
- Added toggle for isolated editing via icon buttons

The TODO's for the (validation) errors and schema  will be done in another PR, this one is big enough already.