### PR TITLE
Add support for edit grid (item) validation in isolation mode

### DIFF
--- a/src/components/forms/EditGrid/EditGrid.stories.tsx
+++ b/src/components/forms/EditGrid/EditGrid.stories.tsx
@@ -1,5 +1,6 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {expect, userEvent, within} from '@storybook/test';
+import {z} from 'zod';
 
 import {TextField} from '@/components/forms';
 import {withFormik} from '@/sb-decorators';
@@ -73,6 +74,10 @@ export const WithIsolation: Story = {
         </span>
       </>
     ),
+    getItemValidationSchema: () => {
+      let fieldSchema = z.string().refine(value => value !== 'Item 1', {message: 'Nooope'});
+      return z.object({myField: fieldSchema});
+    },
     canRemoveItem: () => true,
     canEditItem: () => true,
   },
@@ -87,6 +92,12 @@ export const WithIsolation: Story = {
     await step('Initial data display', async () => {
       expect(field1).toHaveDisplayValue('Item 1');
       expect(field2).toHaveDisplayValue('Item 2');
+    });
+
+    await step('Trigger item 1 validation', async () => {
+      await userEvent.click(field1);
+      await userEvent.tab();
+      expect(await canvas.findByText('Nooope')).toBeVisible();
     });
 
     await step('Edit item 2 without saving', async () => {

--- a/src/components/forms/EditGrid/EditGrid.tsx
+++ b/src/components/forms/EditGrid/EditGrid.tsx
@@ -3,6 +3,7 @@ import {PrimaryActionButton} from '@utrecht/component-library-react';
 import {FieldArray, useFormikContext} from 'formik';
 import {useState} from 'react';
 import {FormattedMessage} from 'react-intl';
+import type {z} from 'zod';
 
 import Icon from '@/components/icons';
 import type {JSONObject, JSONValue} from '@/types';
@@ -51,6 +52,7 @@ interface WithoutIsolation<T> {
    * When editing inline (so *not* in isolation mode), `opts.expanded` will always be `false`.`
    */
   getItemBody: (values: T, index: number, opts: {expanded: false}) => React.ReactNode;
+  getItemValidationSchema?: never;
 }
 
 interface WithIsolation<T> {
@@ -71,6 +73,12 @@ interface WithIsolation<T> {
    * When editing inline (so *not* in isolation mode), `opts.expanded` will always be `false`.`
    */
   getItemBody: (values: T, index: number, opts: {expanded: boolean}) => React.ReactNode;
+  /**
+   * Callback to obtain a Zod validation schema for client-side validation of the item.
+   * Gets passed the item index in the array of values. Return `undefined` to indicate
+   * no validation schema should be applied.
+   */
+  getItemValidationSchema?: (index: number) => z.ZodType<T>;
 }
 
 export type EditGridProps<T> = EditGridBaseProps<T> & (WithoutIsolation<T> | WithIsolation<T>);
@@ -103,6 +111,7 @@ function EditGrid<T extends {[K in keyof T]: JSONValue} = JSONObject>({
                   enableIsolation
                   data={values}
                   canEdit={props.canEditItem?.(values, index) ?? true}
+                  validationSchema={props.getItemValidationSchema?.(index)}
                   saveLabel={props.saveItemLabel}
                   onChange={(newValue: T) => arrayHelpers.replace(index, newValue)}
                   canRemove={canRemoveItem?.(values, index) ?? true}

--- a/src/components/forms/EditGrid/EditGridItem.stories.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.stories.tsx
@@ -1,6 +1,7 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {expect, fn, userEvent, within} from '@storybook/test';
 import {Paragraph} from '@utrecht/component-library-react';
+import {z} from 'zod';
 
 import {TextField} from '@/components/forms';
 
@@ -78,5 +79,26 @@ export const IsolatedModeCanRemove: Story = {
   args: {
     ...IsolatedMode.args,
     canRemove: true,
+  },
+};
+
+export const IsolatedModeWithZodSchema: Story = {
+  args: {
+    ...IsolatedMode.args,
+    enableIsolation: true,
+    validationSchema: z.object({
+      topLevelKey: z.string().max(5), // max 5 characters
+    }),
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', {name: 'Edit item 1'}));
+    const inputField = await canvas.findByLabelText('Top level key');
+    expect(inputField).toHaveDisplayValue('initial');
+    await userEvent.click(inputField);
+    await userEvent.tab();
+
+    expect(await canvas.findByText('String must contain at most 5 character(s)')).toBeVisible();
   },
 };

--- a/src/components/forms/EditGrid/EditGridItem.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.tsx
@@ -1,6 +1,6 @@
 import {Fieldset, FieldsetLegend, SecondaryActionButton} from '@utrecht/component-library-react';
 import {PrimaryActionButton} from '@utrecht/component-library-react';
-import {Formik, setNestedObjectValues} from 'formik';
+import {Formik, FormikErrors, setNestedObjectValues} from 'formik';
 import {useId, useState} from 'react';
 import {useIntl} from 'react-intl';
 import type {z} from 'zod';
@@ -47,6 +47,7 @@ interface WithoutIsolation {
   onChange?: never;
   initiallyExpanded?: false;
   validationSchema?: never;
+  errors?: never;
 }
 
 interface WithIsolation<T> {
@@ -84,6 +85,7 @@ interface WithIsolation<T> {
    */
   initiallyExpanded?: boolean;
   validationSchema?: z.ZodType<T>;
+  errors?: FormikErrors<T>;
 }
 
 export type EditGridItemProps<T> = EditGridItemBaseProps & (WithoutIsolation | WithIsolation<T>);
@@ -109,8 +111,13 @@ function EditGridItem<T extends {[K in keyof T]: JSONValue} = JSONObject>({
     {index: index + 1}
   );
 
-  // TODO
-  const errors: any = {};
+  // if there are errors but the state is not expanded, ensure that it is expanded so
+  // that errors are displayed. Updates to the values result in those errors being
+  // cleared via `props.onChange`.
+  if (props.errors && !expanded) {
+    setExpanded(true);
+  }
+
   return (
     <li className="openforms-editgrid__item">
       <Fieldset>
@@ -132,8 +139,8 @@ function EditGridItem<T extends {[K in keyof T]: JSONValue} = JSONObject>({
           // values, errors, touched state and the validation behaviour (validate individual fields, on blur)
           <Formik<T>
             initialValues={props.data}
-            initialErrors={{}}
-            initialTouched={false ? setNestedObjectValues(errors, true) : undefined}
+            initialErrors={props.errors}
+            initialTouched={props.errors ? setNestedObjectValues(props.errors, true) : undefined}
             // when removing items, the order changes, so we must re-render to display the
             // correct data
             enableReinitialize

--- a/src/components/forms/EditGrid/EditGridItem.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.tsx
@@ -3,10 +3,11 @@ import {PrimaryActionButton} from '@utrecht/component-library-react';
 import {Formik, setNestedObjectValues} from 'formik';
 import {useId, useState} from 'react';
 import {useIntl} from 'react-intl';
+import type {z} from 'zod';
 import {toFormikValidationSchema} from 'zod-formik-adapter';
 
 import Icon from '@/components/icons';
-import type {JSONObject} from '@/types';
+import type {JSONObject, JSONValue} from '@/types';
 
 import EditGridButtonGroup from './EditGridButtonGroup';
 import {IsolationModeButtons, RemoveButton} from './EditGridItemButtons';
@@ -45,6 +46,7 @@ interface WithoutIsolation {
   saveLabel?: never;
   onChange?: never;
   initiallyExpanded?: false;
+  validationSchema?: never;
 }
 
 interface WithIsolation<T> {
@@ -81,11 +83,12 @@ interface WithIsolation<T> {
    * Set to `true` for newly added items so that the user can start editing directly.
    */
   initiallyExpanded?: boolean;
+  validationSchema?: z.ZodType<T>;
 }
 
 export type EditGridItemProps<T> = EditGridItemBaseProps & (WithoutIsolation | WithIsolation<T>);
 
-function EditGridItem<T extends JSONObject = JSONObject>({
+function EditGridItem<T extends {[K in keyof T]: JSONValue} = JSONObject>({
   index,
   heading,
   canRemove,
@@ -108,7 +111,6 @@ function EditGridItem<T extends JSONObject = JSONObject>({
 
   // TODO
   const errors: any = {};
-  const zodSchema: any = null;
   return (
     <li className="openforms-editgrid__item">
       <Fieldset>
@@ -137,7 +139,9 @@ function EditGridItem<T extends JSONObject = JSONObject>({
             enableReinitialize
             validateOnChange={false}
             validateOnBlur={false}
-            validationSchema={false ? toFormikValidationSchema(zodSchema) : undefined}
+            validationSchema={
+              props.validationSchema ? toFormikValidationSchema(props.validationSchema) : undefined
+            }
             onSubmit={async values => {
               if (props.canEdit) props.onChange(values);
               setExpanded(false);


### PR DESCRIPTION
Partly closes #36

* Support Zod validation schema
* Support passing `initialErrors`