### PR TITLE
Add label and description to edit grid low level field

### DIFF
--- a/src/components/forms/EditGrid/EditGrid.stories.tsx
+++ b/src/components/forms/EditGrid/EditGrid.stories.tsx
@@ -17,6 +17,9 @@ export default {
   decorators: [withFormik],
   args: {
     name: 'items',
+    label: 'Items',
+    isRequired: true,
+    description: 'Add as many items as you want!',
     emptyItem: {myField: ''},
     addButtonLabel: undefined,
     getItemHeading: (_, index) => `Item ${index + 1}`,

--- a/src/components/forms/Label.tsx
+++ b/src/components/forms/Label.tsx
@@ -53,7 +53,8 @@ export const LabelContent: React.FC<LabelContentProps> = ({
 LabelContent.displayName = 'LabelContent';
 
 export interface LabelProps {
-  id: string;
+  // id prop is only optional when the label cannot be associated with a single form element
+  id?: string;
   children: React.ReactNode;
   isDisabled?: boolean;
   isRequired?: boolean;


### PR DESCRIPTION
Part of #36

For consistency with other field types, we allow specifying the label and description to the editgrid field as a whole. If no label is provided, the markup shall not be rendered.

Note that this adds the 'required' asterisk to the label, and if no label is displayed for a required field, this will not be visible.