### PR TITLE
Pass getRegistryEntry callback as prop

### DIFF
--- a/src/components/FormioComponent.tsx
+++ b/src/components/FormioComponent.tsx
@@ -32,6 +32,7 @@ const FormioComponent: React.FC<FormioComponentProps> = ({componentDefinition}) 
     <TypeSpecificComponent
       componentDefinition={componentDefinition}
       renderNested={FormioComponent}
+      getRegistryEntry={getRegistryEntry}
     />
   );
 };

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -23,7 +23,17 @@ export interface RenderComponentProps<S extends AnyComponentSchema = AnyComponen
   /**
    * The generic render component for nested components, if applicable.
    */
-  renderNested?: React.FC<FormioComponentProps>;
+  renderNested: React.FC<FormioComponentProps>;
+  /**
+   * The registry entrypoint to look up the component-type specific configuration for
+   * a given component.
+   *
+   * This must be passed dynamically as a prop to avoid circular imports, as the registry
+   * depends on low-level React components/primitives, while the high-level components
+   * use the registry API, which creates an inherent circular dependency when dealing
+   * with tree visitors.
+   */
+  getRegistryEntry: GetRegistryEntry;
 }
 
 export type GetInitialValues<S, V = JSONValue> = (


### PR DESCRIPTION
Required to wrap up #36 

This is the best option which doesn't make us do concession on DX or type safety w/r to the registry. It's still a bit sensitive to possibly introducing circular imports, unfortunately, but now each specialised registry entry at least has access to the registry through it's formField render configuration, which should be sufficient for higher-level/complex components like fieldsets and editgrids.

This will probably lead to some more refactors/reworks for the conditional visibility logic when that's being tackled for the editgrid.