### PR TITLE
Add low-level support for tooltips

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.24.0",
+        "@floating-ui/react": "^0.27.7",
         "@formatjs/cli": "^6.5.1",
         "@fortawesome/fontawesome-free": "^6.7.2",
         "@open-formulieren/design-tokens": "^0.59.0",
@@ -949,6 +950,59 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "dev": true,
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "dev": true,
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.7.tgz",
+      "integrity": "sha512-5V9pwFeiv+95Jlowq/7oiGISSrdXMTs2jfoSy8k+WM6oI/Skm1WWjPdJWeporN2O4UGcsaCJdirKffKayMoPgw==",
+      "dev": true,
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.9",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "dev": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "dev": true
     },
     "node_modules/@formatjs/cli": {
       "version": "6.5.1",
@@ -13173,6 +13227,12 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "dev": true
     },
     "node_modules/tapable": {
       "version": "2.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "@fortawesome/fontawesome-free": ">= 6.4.0",
         "@utrecht/button-group-react": "^1.0.0",
         "date-fns": "^4.0.0",
+        "floating-ui/react": ">= 0.27.5",
         "react": "^18.2.0",
         "react-intl": "^6.6.2 || ^7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -38,13 +38,15 @@
   "homepage": "https://github.com/open-formulieren/formio-renderer#readme",
   "peerDependencies": {
     "@fortawesome/fontawesome-free": ">= 6.4.0",
+    "@utrecht/button-group-react": "^1.0.0",
     "date-fns": "^4.0.0",
+    "floating-ui/react": ">= 0.27.5",
     "react": "^18.2.0",
-    "react-intl": "^6.6.2 || ^7.0.0",
-    "@utrecht/button-group-react": "^1.0.0"
+    "react-intl": "^6.6.2 || ^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.24.0",
+    "@floating-ui/react": "^0.27.7",
     "@formatjs/cli": "^6.5.1",
     "@fortawesome/fontawesome-free": "^6.7.2",
     "@open-formulieren/design-tokens": "^0.59.0",

--- a/src/components/forms/DateField/DateField-InputGroup.stories.tsx
+++ b/src/components/forms/DateField/DateField-InputGroup.stories.tsx
@@ -43,6 +43,10 @@ export const InputGroup: Story = {
   },
   play: async ({canvasElement, step}) => {
     const canvas = within(canvasElement);
+
+    const fieldset = canvas.getByRole('group', {name: /^Test date field/});
+    expect(fieldset).toHaveAccessibleDescription('');
+
     const inputs = canvas.getAllByRole<HTMLInputElement>('textbox');
     expect(inputs).toHaveLength(3);
     await expect(canvas.getByText('Test date field')).toBeVisible();
@@ -139,6 +143,9 @@ export const InputGroupWithInitialValue: Story = {
     expect(canvas.getByLabelText('Year')).toHaveDisplayValue('2024');
 
     expect(canvas.getByText('A validation error')).toBeVisible();
+
+    const fieldset = canvas.getByRole('group', {name: 'Test date field'});
+    expect(fieldset).toHaveAccessibleDescription('A validation error');
   },
 };
 
@@ -248,9 +255,8 @@ export const ValidateOnBlur: Story = {
   },
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
-    const container = (await canvas.findByTestId('inputgroup-container')).querySelector(
-      'fieldset'
-    )!;
+
+    const container = canvas.getByRole('group', {name: 'Validate on blur'});
     expect(container).not.toHaveAttribute('aria-invalid');
 
     const dayInput = canvas.getByLabelText('Day');

--- a/src/components/forms/DateField/DateField-InputGroup.stories.tsx
+++ b/src/components/forms/DateField/DateField-InputGroup.stories.tsx
@@ -37,6 +37,7 @@ export const InputGroup: Story = {
     name: 'test',
     label: 'Test date field',
     description: 'This is a custom description',
+    tooltip: 'A short tooltip.',
     isDisabled: false,
     isRequired: true,
   },

--- a/src/components/forms/DateField/DateField.tsx
+++ b/src/components/forms/DateField/DateField.tsx
@@ -40,6 +40,11 @@ export interface DateFieldProps {
    */
   description?: React.ReactNode;
   /**
+   * Optional tooltip to provide additional information that is not crucial but may
+   * assist users in filling out the field correctly.
+   */
+  tooltip?: React.ReactNode;
+  /**
    * How to autocomplete the field from the browser.
    */
   autoComplete?: string;
@@ -64,6 +69,7 @@ const DateField: React.FC<DateFieldProps> = ({
   isRequired,
   isDisabled,
   description,
+  tooltip,
   autoComplete,
   widget,
 }) => {
@@ -81,6 +87,7 @@ const DateField: React.FC<DateFieldProps> = ({
         <DateInputGroup
           name={name}
           label={label}
+          tooltip={tooltip}
           isRequired={isRequired}
           isDisabled={isDisabled}
           autoComplete={autoComplete}

--- a/src/components/forms/DateField/DateInputGroup.tsx
+++ b/src/components/forms/DateField/DateInputGroup.tsx
@@ -34,6 +34,11 @@ export interface DateInputGroupProps {
    */
   label: React.ReactNode;
   /**
+   * Optional tooltip to provide additional information that is not crucial but may
+   * assist users in filling out the field correctly.
+   */
+  tooltip?: React.ReactNode;
+  /**
    * Required fields get additional markup/styling to indicate this validation requirement.
    */
   isRequired?: boolean;
@@ -62,6 +67,7 @@ export interface DateInputGroupProps {
 const DateInputGroup: React.FC<DateInputGroupProps> = ({
   name,
   label,
+  tooltip,
   isRequired,
   isDisabled,
   autoComplete,
@@ -121,6 +127,7 @@ const DateInputGroup: React.FC<DateInputGroupProps> = ({
   return (
     <InputGroup
       label={label}
+      tooltip={tooltip}
       isRequired={isRequired}
       isDisabled={isDisabled}
       isInvalid={touched && !!error}

--- a/src/components/forms/EditGrid/EditGrid.stories.tsx
+++ b/src/components/forms/EditGrid/EditGrid.stories.tsx
@@ -43,6 +43,12 @@ type Story = StoryObj<typeof EditGrid<ItemData>>;
 
 export const Default: Story = {};
 
+export const WithTooltip: Story = {
+  args: {
+    tooltip: 'Example short tooltip.',
+  },
+};
+
 export const WithCustomButtonLabels: Story = {
   args: {
     enableIsolation: true,

--- a/src/components/forms/EditGrid/EditGrid.tsx
+++ b/src/components/forms/EditGrid/EditGrid.tsx
@@ -8,6 +8,7 @@ import type {z} from 'zod';
 
 import HelpText from '@/components/forms/HelpText';
 import Label from '@/components/forms/Label';
+import Tooltip from '@/components/forms/Tooltip';
 import Icon from '@/components/icons';
 import type {JSONObject, JSONValue} from '@/types';
 
@@ -33,6 +34,11 @@ interface EditGridBaseProps<T> {
    * information that is contextual/background typically belongs in a tooltip.
    */
   description?: React.ReactNode;
+  /**
+   * Optional tooltip to provide additional information that is not crucial but may
+   * assist users in filling out the field correctly.
+   */
+  tooltip?: React.ReactNode;
   /**
    * Callback to return the heading for a single item. Gets passed the item values and
    * index in the array of values.
@@ -105,6 +111,7 @@ function EditGrid<T extends {[K in keyof T]: JSONValue} = JSONObject>({
   label,
   isRequired,
   description,
+  tooltip,
   getItemHeading,
   canRemoveItem,
   removeItemLabel = '',
@@ -117,7 +124,11 @@ function EditGrid<T extends {[K in keyof T]: JSONValue} = JSONObject>({
   const [indexToAutoExpand, setIndexToAutoExpand] = useState<number | null>(null);
   return (
     <FormField type="editgrid" className="utrecht-form-field--openforms">
-      {label && <Label isRequired={isRequired}>{label}</Label>}
+      {label && (
+        <Label isRequired={isRequired} tooltip={tooltip ? <Tooltip>{tooltip}</Tooltip> : undefined}>
+          {label}
+        </Label>
+      )}
       <FieldArray name={name} validateOnChange={false}>
         {arrayHelpers => (
           <div className="openforms-editgrid">

--- a/src/components/forms/InputGroup/InputGroup.tsx
+++ b/src/components/forms/InputGroup/InputGroup.tsx
@@ -1,10 +1,18 @@
 import {Fieldset, FieldsetLegend, Paragraph} from '@utrecht/component-library-react';
+import clsx from 'clsx';
+import {useId} from 'react';
 
 import {LabelContent} from '@/components/forms/Label';
+import Tooltip from '@/components/forms/Tooltip';
 
 export interface InputGroupProps {
   children?: React.ReactNode;
   label: React.ReactNode;
+  /**
+   * Optional tooltip to provide additional information that is not crucial but may
+   * assist users in filling out the field correctly.
+   */
+  tooltip?: React.ReactNode;
   isDisabled?: boolean;
   isRequired?: boolean;
   isInvalid?: boolean;
@@ -14,26 +22,34 @@ export interface InputGroupProps {
 const InputGroup: React.FC<InputGroupProps> = ({
   children,
   label,
+  tooltip,
   isRequired = false,
   isDisabled = false,
   isInvalid = false,
   'aria-describedby': ariaDescribedBy,
-}) => (
-  <Fieldset
-    disabled={isDisabled}
-    invalid={isInvalid}
-    className="utrecht-form-fieldset--openforms"
-    aria-describedby={ariaDescribedBy}
-    data-testid="inputgroup-container"
-  >
-    <FieldsetLegend>
-      <LabelContent isDisabled={isDisabled} isRequired={isRequired}>
-        {label}
-      </LabelContent>
-    </FieldsetLegend>
-    <Paragraph className="openforms-input-group">{children}</Paragraph>
-  </Fieldset>
-);
+}) => {
+  const id = useId();
+  const tooltipId = tooltip ? `${id}-tooltip` : undefined;
+  return (
+    <Fieldset
+      disabled={isDisabled}
+      invalid={isInvalid}
+      className="utrecht-form-fieldset--openforms"
+      aria-describedby={[ariaDescribedBy, tooltipId].filter(Boolean).join(' ')}
+      data-testid="inputgroup-container"
+    >
+      <FieldsetLegend
+        className={clsx({'utrecht-form-fieldset__legend--openforms-tooltip': !!tooltip})}
+      >
+        <LabelContent isDisabled={isDisabled} isRequired={isRequired}>
+          {label}
+        </LabelContent>
+        {tooltip && <Tooltip id={tooltipId}>{tooltip}</Tooltip>}
+      </FieldsetLegend>
+      <Paragraph className="openforms-input-group">{children}</Paragraph>
+    </Fieldset>
+  );
+};
 
 InputGroup.displayName = 'InputGroup';
 

--- a/src/components/forms/InputGroup/InputGroup.tsx
+++ b/src/components/forms/InputGroup/InputGroup.tsx
@@ -1,6 +1,5 @@
 import {Fieldset, FieldsetLegend, Paragraph} from '@utrecht/component-library-react';
 import clsx from 'clsx';
-import {useId} from 'react';
 
 import {LabelContent} from '@/components/forms/Label';
 import Tooltip from '@/components/forms/Tooltip';
@@ -27,29 +26,25 @@ const InputGroup: React.FC<InputGroupProps> = ({
   isDisabled = false,
   isInvalid = false,
   'aria-describedby': ariaDescribedBy,
-}) => {
-  const id = useId();
-  const tooltipId = tooltip ? `${id}-tooltip` : undefined;
-  return (
-    <Fieldset
-      disabled={isDisabled}
-      invalid={isInvalid}
-      className="utrecht-form-fieldset--openforms"
-      aria-describedby={[ariaDescribedBy, tooltipId].filter(Boolean).join(' ')}
-      data-testid="inputgroup-container"
+}) => (
+  <Fieldset
+    disabled={isDisabled}
+    invalid={isInvalid}
+    className="utrecht-form-fieldset--openforms"
+    aria-describedby={ariaDescribedBy}
+    data-testid="inputgroup-container"
+  >
+    <FieldsetLegend
+      className={clsx({'utrecht-form-fieldset__legend--openforms-tooltip': !!tooltip})}
     >
-      <FieldsetLegend
-        className={clsx({'utrecht-form-fieldset__legend--openforms-tooltip': !!tooltip})}
-      >
-        <LabelContent isDisabled={isDisabled} isRequired={isRequired}>
-          {label}
-        </LabelContent>
-        {tooltip && <Tooltip id={tooltipId}>{tooltip}</Tooltip>}
-      </FieldsetLegend>
-      <Paragraph className="openforms-input-group">{children}</Paragraph>
-    </Fieldset>
-  );
-};
+      <LabelContent isDisabled={isDisabled} isRequired={isRequired}>
+        {label}
+      </LabelContent>
+      {tooltip && <Tooltip>{tooltip}</Tooltip>}
+    </FieldsetLegend>
+    <Paragraph className="openforms-input-group">{children}</Paragraph>
+  </Fieldset>
+);
 
 InputGroup.displayName = 'InputGroup';
 

--- a/src/components/forms/InputGroup/index.stories.tsx
+++ b/src/components/forms/InputGroup/index.stories.tsx
@@ -1,4 +1,5 @@
 import {Meta, StoryObj} from '@storybook/react';
+import {expect, within} from '@storybook/test';
 import {FormLabel, Textbox} from '@utrecht/component-library-react';
 
 import '@/components/forms/TextField/TextField.scss';
@@ -57,5 +58,20 @@ export const Disabled: Story = {
 export const Invalid: Story = {
   args: {
     isInvalid: true,
+  },
+};
+
+export const WithValidationErrorAndTooltip: Story = {
+  ...Invalid,
+  args: {
+    ...Invalid.args,
+    tooltip: 'Tooltip content.',
+  },
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const fieldset = canvas.getByRole('group', {name: /^Input group/});
+    expect(fieldset).toHaveAccessibleDescription('');
   },
 };

--- a/src/components/forms/InputGroup/index.stories.tsx
+++ b/src/components/forms/InputGroup/index.stories.tsx
@@ -42,6 +42,12 @@ type Story = StoryObj<StoryArgs>;
 
 export const Default: Story = {};
 
+export const WithTooltip: Story = {
+  args: {
+    tooltip: 'Example short tooltip.',
+  },
+};
+
 export const Disabled: Story = {
   args: {
     isDisabled: true,

--- a/src/components/forms/Label.tsx
+++ b/src/components/forms/Label.tsx
@@ -58,13 +58,25 @@ export interface LabelProps {
   children: React.ReactNode;
   isDisabled?: boolean;
   isRequired?: boolean;
+  tooltip?: React.ReactNode;
 }
 
-const Label: React.FC<LabelProps> = ({id, isRequired = false, isDisabled = false, children}) => (
-  <div className="utrecht-form-field__label">
+const Label: React.FC<LabelProps> = ({
+  id,
+  isRequired = false,
+  isDisabled = false,
+  tooltip,
+  children,
+}) => (
+  <div
+    className={clsx('utrecht-form-field__label', {
+      'utrecht-form-field__label--openforms-tooltip': !!tooltip,
+    })}
+  >
     <LabelContent id={id} isRequired={isRequired} isDisabled={isDisabled}>
       {children}
     </LabelContent>
+    {tooltip}
   </div>
 );
 

--- a/src/components/forms/RadioField/RadioField.scss
+++ b/src/components/forms/RadioField/RadioField.scss
@@ -8,7 +8,14 @@
 
 // Design tokens: see src/components/radio-field.tokens.json
 
-// Extensions on NL DS component
+// Extensions on NL DS components
+.utrecht-form-fieldset {
+  @include bem.element('legend') {
+    margin-block-end: var(--utrecht-form-field-label-margin-block-end);
+    margin-block-start: 0;
+  }
+}
+
 .utrecht-form-field {
   @include bem.modifier('openforms') {
     &.utrecht-form-field--radio {

--- a/src/components/forms/RadioField/RadioField.stories.ts
+++ b/src/components/forms/RadioField/RadioField.stories.ts
@@ -49,6 +49,13 @@ export const Default: Story = {
   },
 };
 
+export const WithTooltip: Story = {
+  args: {
+    isRequired: true,
+    tooltip: 'Example short tooltip.',
+  },
+};
+
 export const ValidationError: Story = {
   name: 'Validation error',
   args: {

--- a/src/components/forms/RadioField/RadioField.stories.ts
+++ b/src/components/forms/RadioField/RadioField.stories.ts
@@ -82,6 +82,26 @@ export const ValidationError: Story = {
   },
 };
 
+export const WithValidationErrorAndTooltip: Story = {
+  ...ValidationError,
+  args: {
+    ...ValidationError.args,
+    tooltip: 'Tooltip content.',
+  },
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const fieldset = canvas.getByRole('radiogroup', {name: /^Radio/});
+    expect(fieldset).toHaveAccessibleDescription('Description above the errors');
+
+    const inputs = canvas.getAllByRole('radio');
+    for (const input of inputs) {
+      expect(input).toHaveAccessibleDescription('invalid');
+    }
+  },
+};
+
 export const NoAsterisks: Story = {
   name: 'No asterisk for required',
   decorators: [withRenderSettingsProvider],

--- a/src/components/forms/RadioField/RadioField.tsx
+++ b/src/components/forms/RadioField/RadioField.tsx
@@ -1,9 +1,11 @@
 import {Fieldset, FieldsetLegend} from '@utrecht/component-library-react';
+import clsx from 'clsx';
 import {LabelContent} from 'components/forms/Label';
 import {useField} from 'formik';
 import {useId} from 'react';
 
 import HelpText from '@/components/forms/HelpText';
+import Tooltip from '@/components/forms/Tooltip';
 import ValidationErrors from '@/components/forms/ValidationErrors';
 
 import './RadioField.scss';
@@ -41,6 +43,11 @@ export interface RadioFieldProps {
    */
   description?: React.ReactNode;
   /**
+   * Optional tooltip to provide additional information that is not crucial but may
+   * assist users in filling out the field correctly.
+   */
+  tooltip?: React.ReactNode;
+  /**
    * Array of possible choices for the field. Only one can be selected.
    */
   options: RadioOption[];
@@ -58,6 +65,7 @@ const RadioField: React.FC<RadioFieldProps> = ({
   description = '',
   isDisabled = false,
   options = [],
+  tooltip,
 }) => {
   const [, {error = '', touched}] = useField({name, type: 'radio'});
   const id = useId();
@@ -65,6 +73,7 @@ const RadioField: React.FC<RadioFieldProps> = ({
   const invalid = touched && !!error;
   const errorMessageId = invalid ? `${id}-error-message` : undefined;
   const descriptionid = `${id}-description`;
+  const tooltipId = tooltip ? `${id}-tooltip` : undefined;
 
   return (
     <Fieldset
@@ -74,10 +83,13 @@ const RadioField: React.FC<RadioFieldProps> = ({
       role="radiogroup"
       aria-describedby={description ? descriptionid : undefined}
     >
-      <FieldsetLegend>
+      <FieldsetLegend
+        className={clsx({'utrecht-form-fieldset__legend--openforms-tooltip': !!tooltip})}
+      >
         <LabelContent isDisabled={isDisabled} isRequired={isRequired}>
           {label}
         </LabelContent>
+        {tooltip && <Tooltip id={tooltipId}>{tooltip}</Tooltip>}
       </FieldsetLegend>
 
       {options.map(({value, label: optionLabel}, index) => (
@@ -88,7 +100,7 @@ const RadioField: React.FC<RadioFieldProps> = ({
           label={optionLabel}
           id={id}
           index={index}
-          errorMessageId={errorMessageId}
+          aria-describedby={[tooltipId, errorMessageId].filter(Boolean).join(' ')}
           isDisabled={isDisabled}
         />
       ))}

--- a/src/components/forms/RadioField/RadioField.tsx
+++ b/src/components/forms/RadioField/RadioField.tsx
@@ -73,7 +73,6 @@ const RadioField: React.FC<RadioFieldProps> = ({
   const invalid = touched && !!error;
   const errorMessageId = invalid ? `${id}-error-message` : undefined;
   const descriptionid = `${id}-description`;
-  const tooltipId = tooltip ? `${id}-tooltip` : undefined;
 
   return (
     <Fieldset
@@ -89,7 +88,7 @@ const RadioField: React.FC<RadioFieldProps> = ({
         <LabelContent isDisabled={isDisabled} isRequired={isRequired}>
           {label}
         </LabelContent>
-        {tooltip && <Tooltip id={tooltipId}>{tooltip}</Tooltip>}
+        {tooltip && <Tooltip>{tooltip}</Tooltip>}
       </FieldsetLegend>
 
       {options.map(({value, label: optionLabel}, index) => (
@@ -100,7 +99,7 @@ const RadioField: React.FC<RadioFieldProps> = ({
           label={optionLabel}
           id={id}
           index={index}
-          aria-describedby={[tooltipId, errorMessageId].filter(Boolean).join(' ')}
+          aria-describedby={errorMessageId}
           isDisabled={isDisabled}
         />
       ))}

--- a/src/components/forms/RadioField/RadioOption.tsx
+++ b/src/components/forms/RadioField/RadioOption.tsx
@@ -7,7 +7,7 @@ export interface RadioOptionProps {
   label: React.ReactNode;
   id: string;
   index: number;
-  errorMessageId?: string;
+  ['aria-describedby']?: string;
   isDisabled?: boolean;
 }
 
@@ -17,7 +17,7 @@ const RadioOption: React.FC<RadioOptionProps> = ({
   label,
   id,
   index,
-  errorMessageId,
+  ['aria-describedby']: ariaDescribedBy,
   isDisabled,
 }) => {
   const {validateField} = useFormikContext();
@@ -28,7 +28,7 @@ const RadioOption: React.FC<RadioOptionProps> = ({
       <RadioButton
         className="utrecht-form-field__input"
         id={`${id}-opt-${index}`}
-        aria-describedby={errorMessageId}
+        aria-describedby={ariaDescribedBy}
         {...props}
         onBlur={async e => {
           props.onBlur(e);

--- a/src/components/forms/TextField/TextField.stories.ts
+++ b/src/components/forms/TextField/TextField.stories.ts
@@ -41,6 +41,17 @@ export const Default: Story = {
   },
 };
 
+export const WithTooltip: Story = {
+  args: {
+    name: 'test',
+    label: 'test',
+    description: 'This is a custom description',
+    isDisabled: false,
+    isRequired: true,
+    tooltip: 'Example short tooltip.',
+  },
+};
+
 export const ValidationError: Story = {
   name: 'Validation error',
   parameters: {

--- a/src/components/forms/TextField/TextField.stories.ts
+++ b/src/components/forms/TextField/TextField.stories.ts
@@ -80,6 +80,23 @@ export const ValidationError: Story = {
   },
 };
 
+export const WithValidationErrorAndTooltip: Story = {
+  ...ValidationError,
+  args: {
+    ...ValidationError.args,
+    tooltip: 'Tooltip content.',
+  },
+
+  play: async ({canvasElement, args}) => {
+    const canvas = within(canvasElement);
+
+    const input = canvas.getByLabelText(args.label as string);
+    // the tooltip gets announced by itself and we do not expect it to be in the input
+    // description too, as otherwise screenreaders encounter it twice.
+    expect(input).toHaveAccessibleDescription('invalid');
+  },
+};
+
 export const NoAsterisks: Story = {
   name: 'No asterisk for required',
   decorators: [withRenderSettingsProvider],

--- a/src/components/forms/TextField/TextField.tsx
+++ b/src/components/forms/TextField/TextField.tsx
@@ -5,6 +5,7 @@ import {useId} from 'react';
 
 import HelpText from '@/components/forms/HelpText';
 import Label from '@/components/forms/Label';
+import Tooltip from '@/components/forms/Tooltip';
 import ValidationErrors from '@/components/forms/ValidationErrors';
 
 import './TextField.scss';
@@ -36,6 +37,11 @@ export interface TextFieldProps {
    */
   description?: React.ReactNode;
   /**
+   * Optional tooltip to provide additional information that is not crucial but may
+   * assist users in filling out the field correctly.
+   */
+  tooltip?: React.ReactNode;
+  /**
    * Placeholder when no (default) value is available.
    */
   placeholder?: string;
@@ -54,6 +60,7 @@ const TextField: React.FC<TextFieldProps & TextboxProps> = ({
   description = '',
   isDisabled = false,
   placeholder,
+  tooltip,
   ...extraProps
 }) => {
   const {validateField} = useFormikContext();
@@ -62,10 +69,16 @@ const TextField: React.FC<TextFieldProps & TextboxProps> = ({
 
   const invalid = touched && !!error;
   const errorMessageId = invalid ? `${id}-error-message` : undefined;
+  const tooltipId = tooltip ? `${id}-tooltip` : undefined;
 
   return (
     <FormField type="text" invalid={invalid} className="utrecht-form-field--openforms">
-      <Label id={id} isRequired={isRequired} isDisabled={isDisabled}>
+      <Label
+        id={id}
+        isRequired={isRequired}
+        isDisabled={isDisabled}
+        tooltip={tooltip ? <Tooltip id={tooltipId}>{tooltip}</Tooltip> : undefined}
+      >
         {label}
       </Label>
       <Paragraph>
@@ -79,7 +92,7 @@ const TextField: React.FC<TextFieldProps & TextboxProps> = ({
           id={id}
           disabled={isDisabled}
           invalid={invalid}
-          aria-describedby={errorMessageId}
+          aria-describedby={[tooltipId, errorMessageId].filter(Boolean).join(' ')}
           placeholder={placeholder}
           {...extraProps}
         />

--- a/src/components/forms/TextField/TextField.tsx
+++ b/src/components/forms/TextField/TextField.tsx
@@ -69,7 +69,6 @@ const TextField: React.FC<TextFieldProps & TextboxProps> = ({
 
   const invalid = touched && !!error;
   const errorMessageId = invalid ? `${id}-error-message` : undefined;
-  const tooltipId = tooltip ? `${id}-tooltip` : undefined;
 
   return (
     <FormField type="text" invalid={invalid} className="utrecht-form-field--openforms">
@@ -77,7 +76,7 @@ const TextField: React.FC<TextFieldProps & TextboxProps> = ({
         id={id}
         isRequired={isRequired}
         isDisabled={isDisabled}
-        tooltip={tooltip ? <Tooltip id={tooltipId}>{tooltip}</Tooltip> : undefined}
+        tooltip={tooltip ? <Tooltip>{tooltip}</Tooltip> : undefined}
       >
         {label}
       </Label>
@@ -92,7 +91,7 @@ const TextField: React.FC<TextFieldProps & TextboxProps> = ({
           id={id}
           disabled={isDisabled}
           invalid={invalid}
-          aria-describedby={[tooltipId, errorMessageId].filter(Boolean).join(' ')}
+          aria-describedby={errorMessageId}
           placeholder={placeholder}
           {...extraProps}
         />

--- a/src/components/forms/Tooltip.scss
+++ b/src/components/forms/Tooltip.scss
@@ -103,12 +103,24 @@
 }
 
 // Extensions to allow tooltips inside utrecht-form-field__label
+@mixin label-with-tooltip {
+  display: flex;
+  align-items: var(--of-utrecht-form-field-label-tooltip-align-items, center);
+  column-gap: var(--of-utrecht-form-field-label-tooltip-column-gap, 4px);
+}
+
 .utrecht-form-field {
   @include bem.element('label') {
     @include bem.modifier('openforms-tooltip') {
-      display: flex;
-      align-items: var(--of-utrecht-form-field-label-tooltip-align-items, center);
-      column-gap: var(--of-utrecht-form-field-label-tooltip-column-gap, 4px);
+      @include label-with-tooltip;
+    }
+  }
+}
+
+.utrecht-form-fieldset {
+  @include bem.element('legend') {
+    @include bem.modifier('openforms-tooltip') {
+      @include label-with-tooltip;
     }
   }
 }

--- a/src/components/forms/Tooltip.scss
+++ b/src/components/forms/Tooltip.scss
@@ -1,0 +1,103 @@
+@use '@utrecht/components/icon';
+
+@use '@/scss/bem';
+
+.openforms-tooltip-icon {
+  color: var(--of-tooltip-icon-color, inherit);
+}
+
+.openforms-tooltip {
+  z-index: 1;
+  display: none;
+
+  &,
+  & * {
+    box-sizing: border-box;
+  }
+
+  @include bem.modifier('visible') {
+    display: flex;
+    align-items: center;
+  }
+
+  // handle the tooltip placement
+  @include bem.modifier('right') {
+    .openforms-tooltip__content {
+      transform: translateX(var(--of-tooltip-offset));
+    }
+
+    .openforms-tooltip__arrow {
+      left: calc(var(--of-tooltip-arrow-width) * -1);
+      transform: translateX(var(--of-tooltip-offset));
+
+      &:before {
+        border-left-width: 0;
+        border-right-width: var(--of-tooltip-arrow-width);
+        border-right-color: var(--of-tooltip-arrow-color);
+        right: 0;
+      }
+    }
+  }
+
+  @include bem.modifier('left') {
+    .openforms-tooltip__content {
+      transform: translateX(calc(var(--of-tooltip-offset) * -1));
+    }
+
+    .openforms-tooltip__arrow {
+      right: calc(var(--of-tooltip-arrow-width) * -1);
+      transform: translateX(calc(var(--of-tooltip-offset) * -1));
+
+      &:before {
+        border-right-width: 0;
+        border-left-width: var(--of-tooltip-arrow-width);
+        border-left-color: var(--of-tooltip-arrow-color);
+        left: 0;
+      }
+    }
+  }
+
+  @include bem.element('arrow') {
+    --_of-tooltip-arrow-block-size: var(
+      --of-tooltip-arrow-block-size,
+      var(--of-tooltip-arrow-height)
+    );
+    --_of-tooltip-arrow-inline-size: var(
+      --of-tooltip-arrow-inline-size,
+      var(--of-tooltip-arrow-width)
+    );
+
+    position: absolute;
+    z-index: 2;
+    block-size: var(--_of-tooltip-arrow-block-size);
+    inline-size: var(--_of-tooltip-arrow-inline-size);
+
+    &:before {
+      position: absolute;
+      content: '';
+      border-color: transparent;
+      border-style: solid;
+      border-block-end-width: calc(var(--_of-tooltip-arrow-block-size) * 0.5);
+      border-block-start-width: calc(var(--_of-tooltip-arrow-block-size) * 0.5);
+    }
+  }
+
+  @include bem.element('content') {
+    background-color: var(
+      --of-tooltip-background-color,
+      var(--utrecht-document-background-color, #dfdfdf)
+    );
+    border-style: var(--of-tooltip-border-style, solid);
+    border-width: var(--of-tooltip-border-width);
+    border-color: var(--of-tooltip-border-color, black);
+    border-radius: var(--of-tooltip-border-radius, 0);
+    box-shadow: var(--of-tooltip-box-shadow, unset);
+    color: var(--of-tooltip-color, inherit);
+    font-family: var(--of-tooltip-font-family, var(--utrecht-document-font-family));
+    font-size: var(--of-tooltip-font-size);
+    padding-block-end: var(--of-tooltip-padding-block-end);
+    padding-block-start: var(--of-tooltip-padding-block-start);
+    padding-inline-end: var(--of-tooltip-padding-inline-end);
+    padding-inline-start: var(--of-tooltip-padding-inline-start);
+  }
+}

--- a/src/components/forms/Tooltip.scss
+++ b/src/components/forms/Tooltip.scss
@@ -101,3 +101,14 @@
     padding-inline-start: var(--of-tooltip-padding-inline-start);
   }
 }
+
+// Extensions to allow tooltips inside utrecht-form-field__label
+.utrecht-form-field {
+  @include bem.element('label') {
+    @include bem.modifier('openforms-tooltip') {
+      display: flex;
+      align-items: var(--of-utrecht-form-field-label-tooltip-align-items, center);
+      column-gap: var(--of-utrecht-form-field-label-tooltip-column-gap, 4px);
+    }
+  }
+}

--- a/src/components/forms/Tooltip.stories.tsx
+++ b/src/components/forms/Tooltip.stories.tsx
@@ -1,0 +1,37 @@
+import {Meta, StoryObj} from '@storybook/react';
+import {expect, userEvent, within} from '@storybook/test';
+
+import Tooltip from './Tooltip';
+
+export default {
+  title: 'Internal API / Forms / Tooltip',
+  component: Tooltip,
+  args: {
+    children: 'Escaped text inside the <strong>tooltip</strong>',
+  },
+} satisfies Meta<typeof Tooltip>;
+
+type Story = StoryObj<typeof Tooltip>;
+
+export const Default: Story = {};
+
+export const DefaultPlacement: Story = {
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await userEvent.keyboard('[Tab]');
+    expect(
+      await canvas.findByText('Escaped text inside the <strong>tooltip</strong>')
+    ).toBeVisible();
+  },
+};
+
+export const PlacementRight: Story = {
+  ...DefaultPlacement,
+  decorators: [
+    Story => (
+      <div style={{display: 'flex', justifyContent: 'end'}}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/src/components/forms/Tooltip.tsx
+++ b/src/components/forms/Tooltip.tsx
@@ -84,7 +84,7 @@ const Tooltip: React.FC<TooltipProps> = ({children, id}) => {
         <Icon icon="tooltip" className="openforms-tooltip-icon" />
       </UtrechtIcon>
       {/* The DOM node must always be rendered to support screen readers - handle visibility with CSS */}
-      <div
+      <span
         className={clsx('openforms-tooltip', `openforms-tooltip--${placement}`, {
           'openforms-tooltip--visible': isOpen,
         })}
@@ -93,9 +93,9 @@ const Tooltip: React.FC<TooltipProps> = ({children, id}) => {
         ref={refs.setFloating}
         {...getFloatingProps()}
       >
-        <div className="openforms-tooltip__arrow" />
-        <div className="openforms-tooltip__content">{children}</div>
-      </div>
+        <span className="openforms-tooltip__arrow" />
+        <span className="openforms-tooltip__content">{children}</span>
+      </span>
     </>
   );
 };

--- a/src/components/forms/Tooltip.tsx
+++ b/src/components/forms/Tooltip.tsx
@@ -1,0 +1,103 @@
+/**
+ * Implements a tooltip using float-ui.
+ *
+ * Guide from https://floating-ui.com/docs/tooltip.
+ *
+ * Will at some point be obsoleted by the HTML popover/anchor APIs, but right now not
+ * all major browsers support this yet. See:
+ * https://www.voorhoede.nl/en/blog/the-popover-api-your-new-best-friend-for-tooltips/
+ */
+import {
+  autoUpdate,
+  flip,
+  offset,
+  shift,
+  useDismiss,
+  useFloating,
+  useFocus,
+  useHover,
+  useInteractions,
+  useRole,
+} from '@floating-ui/react';
+import {Icon as UtrechtIcon} from '@utrecht/component-library-react';
+import clsx from 'clsx';
+import {useEffect, useState} from 'react';
+import {useIntl} from 'react-intl';
+
+import Icon from '@/components/icons';
+
+import './Tooltip.scss';
+
+export interface TooltipProps {
+  children: React.ReactNode;
+  id?: string; // recommended to pass and relate with aria-describedby
+}
+
+const Tooltip: React.FC<TooltipProps> = ({children, id}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const intl = useIntl();
+
+  const {update, refs, elements, floatingStyles, context, placement} = useFloating({
+    open: isOpen,
+    onOpenChange: setIsOpen,
+    middleware: [offset(10), flip(), shift()],
+    placement: 'right',
+  });
+
+  const hover = useHover(context, {
+    move: false,
+    delay: {
+      open: 0,
+      close: 100,
+    },
+  });
+  const focus = useFocus(context);
+  const dismiss = useDismiss(context);
+  const role = useRole(context, {role: 'tooltip'});
+
+  const {getReferenceProps, getFloatingProps} = useInteractions([hover, focus, dismiss, role]);
+
+  useEffect(() => {
+    if (isOpen && elements.reference && elements.floating) {
+      const cleanup = autoUpdate(elements.reference, elements.floating, update);
+      return cleanup;
+    }
+    return;
+  }, [isOpen, elements, update]);
+
+  if (!children) return null;
+
+  return (
+    <>
+      <UtrechtIcon
+        ref={refs.setReference}
+        // ensure it's keyboard-navigation capable
+        tabIndex={0}
+        // must show up in the accessible tree
+        aria-hidden="false"
+        aria-label={intl.formatMessage({
+          description: 'Tooltip icon label',
+          defaultMessage: 'Show tooltip',
+        })}
+        {...getReferenceProps()}
+      >
+        <Icon icon="tooltip" className="openforms-tooltip-icon" />
+      </UtrechtIcon>
+      {/* The DOM node must always be rendered to support screen readers - handle visibility with CSS */}
+      <div
+        className={clsx('openforms-tooltip', `openforms-tooltip--${placement}`, {
+          'openforms-tooltip--visible': isOpen,
+        })}
+        id={id}
+        style={floatingStyles}
+        ref={refs.setFloating}
+        {...getFloatingProps()}
+      >
+        <div className="openforms-tooltip__arrow" />
+        <div className="openforms-tooltip__content">{children}</div>
+      </div>
+    </>
+  );
+};
+
+export default Tooltip;

--- a/src/components/forms/Tooltip.tsx
+++ b/src/components/forms/Tooltip.tsx
@@ -30,10 +30,9 @@ import './Tooltip.scss';
 
 export interface TooltipProps {
   children: React.ReactNode;
-  id?: string; // recommended to pass and relate with aria-describedby
 }
 
-const Tooltip: React.FC<TooltipProps> = ({children, id}) => {
+const Tooltip: React.FC<TooltipProps> = ({children}) => {
   const [isOpen, setIsOpen] = useState(false);
   const intl = useIntl();
 
@@ -88,7 +87,6 @@ const Tooltip: React.FC<TooltipProps> = ({children, id}) => {
         className={clsx('openforms-tooltip', `openforms-tooltip--${placement}`, {
           'openforms-tooltip--visible': isOpen,
         })}
-        id={id}
         style={floatingStyles}
         ref={refs.setFloating}
         {...getFloatingProps()}

--- a/src/components/icons/FontAwesome.tsx
+++ b/src/components/icons/FontAwesome.tsx
@@ -9,6 +9,7 @@ const FA_MAP: Record<RendererIcon, string> = {
   add: 'plus',
   edit: 'edit',
   remove: 'trash-can',
+  tooltip: 'question-circle',
 };
 
 interface FontAwesomeSolidIconProps {

--- a/src/components/icons/types.ts
+++ b/src/components/icons/types.ts
@@ -2,4 +2,4 @@
  * The semantic names of icons that we use. Each icon library alternative should provide
  * an actual icon for each union member.
  */
-export type RendererIcon = 'add' | 'edit' | 'remove';
+export type RendererIcon = 'add' | 'edit' | 'remove' | 'tooltip';


### PR DESCRIPTION
Closes #93 

This sets up the low-level components to support tooltips next to labels.

This approach should be properly accessible to screenreaders and support keyboard navigation.