### PR TITLE
Update label markup & styles in Storybook

### DIFF
--- a/src/components/forms/DateField/DatePartInput.scss
+++ b/src/components/forms/DateField/DatePartInput.scss
@@ -1,3 +1,4 @@
+@use '@/components/forms/TextField/TextField';
 @use '@/scss/bem';
 @use '@/scss/form-field-override';
 

--- a/src/components/forms/EditGrid/EditGridItem.stories.tsx
+++ b/src/components/forms/EditGrid/EditGridItem.stories.tsx
@@ -1,6 +1,7 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {expect, fn, userEvent, within} from '@storybook/test';
 import {Paragraph} from '@utrecht/component-library-react';
+import '@utrecht/components/paragraph';
 import {z} from 'zod';
 
 import {TextField} from '@/components/forms';

--- a/src/components/forms/InputGroup/InputGroup.scss
+++ b/src/components/forms/InputGroup/InputGroup.scss
@@ -1,6 +1,8 @@
 @use '@utrecht/components/paragraph';
+@use '@utrecht/components/form-fieldset';
 
 @use '@/scss/bem';
+@use '@/scss/form-field-override';
 
 .openforms-input-group {
   display: flex;

--- a/src/components/forms/InputGroup/InputGroup.scss
+++ b/src/components/forms/InputGroup/InputGroup.scss
@@ -1,3 +1,5 @@
+@use '@utrecht/components/paragraph';
+
 @use '@/scss/bem';
 
 .openforms-input-group {

--- a/src/components/forms/InputGroup/InputGroup.tsx
+++ b/src/components/forms/InputGroup/InputGroup.tsx
@@ -26,7 +26,7 @@ const InputGroup: React.FC<InputGroupProps> = ({
     aria-describedby={ariaDescribedBy}
     data-testid="inputgroup-container"
   >
-    <FieldsetLegend className="utrecht-form-field__label">
+    <FieldsetLegend>
       <LabelContent isDisabled={isDisabled} isRequired={isRequired}>
         {label}
       </LabelContent>

--- a/src/components/forms/InputGroup/index.stories.tsx
+++ b/src/components/forms/InputGroup/index.stories.tsx
@@ -1,6 +1,8 @@
 import {Meta, StoryObj} from '@storybook/react';
 import {FormLabel, Textbox} from '@utrecht/component-library-react';
 
+import '@/components/forms/TextField/TextField.scss';
+
 import {InputGroup, InputGroupItem} from '.';
 import {InputGroupProps} from './InputGroup';
 

--- a/src/components/forms/Label.scss
+++ b/src/components/forms/Label.scss
@@ -1,5 +1,4 @@
 @use '@utrecht/components/form-label' as form-label;
-@use '@utrecht/components/paragraph' as paragraph;
 
 @use '@/scss/bem';
 

--- a/src/components/forms/Label.tsx
+++ b/src/components/forms/Label.tsx
@@ -1,4 +1,4 @@
-import {FormLabel, Paragraph} from '@utrecht/component-library-react';
+import {FormLabel} from '@utrecht/component-library-react';
 import clsx from 'clsx';
 import {FormattedMessage} from 'react-intl';
 
@@ -61,11 +61,11 @@ export interface LabelProps {
 }
 
 const Label: React.FC<LabelProps> = ({id, isRequired = false, isDisabled = false, children}) => (
-  <Paragraph className="utrecht-form-field__label">
+  <div className="utrecht-form-field__label">
     <LabelContent id={id} isRequired={isRequired} isDisabled={isDisabled}>
       {children}
     </LabelContent>
-  </Paragraph>
+  </div>
 );
 
 Label.displayName = 'Label';

--- a/src/components/forms/RadioField/RadioField.scss
+++ b/src/components/forms/RadioField/RadioField.scss
@@ -1,6 +1,3 @@
-// NOTE: the import order matters here, otherwise paragraph styles overwrite the styles
-// of form-field
-@use '@utrecht/components/paragraph' as paragraph;
 @use '@utrecht/components/form-field' as form-field;
 @use '@utrecht/components/form-fieldset' as form-fieldset;
 @use '@utrecht/components/textbox' as textbox;

--- a/src/components/forms/RadioField/RadioField.tsx
+++ b/src/components/forms/RadioField/RadioField.tsx
@@ -74,7 +74,7 @@ const RadioField: React.FC<RadioFieldProps> = ({
       role="radiogroup"
       aria-describedby={description ? descriptionid : undefined}
     >
-      <FieldsetLegend className="utrecht-form-field__label">
+      <FieldsetLegend>
         <LabelContent isDisabled={isDisabled} isRequired={isRequired}>
           {label}
         </LabelContent>

--- a/src/components/forms/RadioField/RadioOption.tsx
+++ b/src/components/forms/RadioField/RadioOption.tsx
@@ -1,4 +1,4 @@
-import {FormField, FormLabel, Paragraph, RadioButton} from '@utrecht/component-library-react';
+import {FormField, FormLabel, RadioButton} from '@utrecht/component-library-react';
 import {useField, useFormikContext} from 'formik';
 
 export interface RadioOptionProps {
@@ -36,7 +36,7 @@ const RadioOption: React.FC<RadioOptionProps> = ({
         }}
         value={value}
       />
-      <Paragraph className="utrecht-form-field__label utrecht-form-field__label--radio">
+      <div className="utrecht-form-field__label utrecht-form-field__label--radio">
         <FormLabel
           htmlFor={`${id}-opt-${index}`}
           disabled={isDisabled}
@@ -45,7 +45,7 @@ const RadioOption: React.FC<RadioOptionProps> = ({
         >
           {label}
         </FormLabel>
-      </Paragraph>
+      </div>
     </FormField>
   );
 };

--- a/src/components/forms/TextField/TextField.scss
+++ b/src/components/forms/TextField/TextField.scss
@@ -1,7 +1,5 @@
-// NOTE: the import order matters here, otherwise paragraph styles overwrite the styles
-// of form-field
-@use '@utrecht/components/paragraph' as paragraph;
 @use '@utrecht/components/form-field' as form-field;
+@use '@utrecht/components/paragraph' as paragraph;
 @use '@utrecht/components/textbox' as textbox;
 
 @use '@/scss/bem';

--- a/src/scss/form-field-override.scss
+++ b/src/scss/form-field-override.scss
@@ -15,6 +15,16 @@
   padding-block-end: var(--utrecht-form-field-invalid-padding-inline-start);
 }
 
+// Extensions on NL DS components
+.utrecht-form-fieldset {
+  @include bem.element('legend') {
+    &:has(.utrecht-form-label--openforms) {
+      margin-block-end: var(--utrecht-form-field-label-margin-block-end);
+      margin-block-start: 0;
+    }
+  }
+}
+
 // Overrides of the utrecht form field styles for our own theme
 .openforms-theme {
   .utrecht-form-field {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
+      '@/components': resolve(__dirname, 'src/components'),
       '@/scss': resolve(__dirname, 'src/scss'),
     },
   },


### PR DESCRIPTION
Following the example on https://nl-design-system.github.io/utrecht/storybook/\?path\=/docs/css_css-form-field--docs, we no longer render the form field label in an utrecht-paragraph, but instead we use a plain div with the utrecht-form-field__label class name.

This fixes the CSS precedence issues for the margin below the label, which both the paragraph and the form field try to set and the CSS rules that come last win.

These changes should be visually identical.