### PR TITLE
Implement tooltip support for formio components

### DIFF
--- a/src/registry/bsn/index.stories.tsx
+++ b/src/registry/bsn/index.stories.tsx
@@ -39,6 +39,30 @@ export const MinimalConfiguration: Story = {
   },
 };
 
+export const WithTooltip: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'bsn',
+      key: 'my.bsn',
+      label: 'A BSN field',
+      tooltip: 'Surprise!',
+      description: 'A description',
+      inputMask: '999999999',
+      validateOn: 'blur',
+    } satisfies BsnComponentSchema,
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          bsn: '',
+        },
+      },
+    },
+  },
+};
+
 interface ValidationStoryArgs {
   componentDefinition: BsnComponentSchema;
   onSubmit: FormioFormProps['onSubmit'];

--- a/src/registry/bsn/index.tsx
+++ b/src/registry/bsn/index.tsx
@@ -12,13 +12,14 @@ export interface FormioBSNProps {
 }
 
 export const FormioBSN: React.FC<FormioBSNProps> = ({
-  componentDefinition: {key, label, description, validate},
+  componentDefinition: {key, label, tooltip, description, validate},
 }) => {
   return (
     <TextField
       name={key}
       type="text"
       label={label}
+      tooltip={tooltip}
       description={description}
       isRequired={validate?.required}
       pattern="[0-9]{9}"

--- a/src/registry/date/index.stories.tsx
+++ b/src/registry/date/index.stories.tsx
@@ -37,6 +37,28 @@ export const MinimalConfiguration: Story = {
   },
 };
 
+export const WithTooltip: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'date',
+      key: 'my.date',
+      label: 'Your date',
+      tooltip: 'Surprise!',
+      description: 'A description',
+    } satisfies DateComponentSchema,
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          date: '',
+        },
+      },
+    },
+  },
+};
+
 interface ValidationStoryArgs {
   componentDefinition: DateComponentSchema;
   onSubmit: FormioFormProps['onSubmit'];

--- a/src/registry/date/index.tsx
+++ b/src/registry/date/index.tsx
@@ -12,12 +12,13 @@ export interface FormioDateProps {
 }
 
 export const FormioDate: React.FC<FormioDateProps> = ({
-  componentDefinition: {key, label, description, validate},
+  componentDefinition: {key, label, tooltip, description, validate},
 }) => {
   return (
     <DateField
       name={key}
       label={label}
+      tooltip={tooltip}
       description={description}
       isRequired={validate?.required}
       widget="inputGroup"

--- a/src/registry/editgrid/index.stories.ts
+++ b/src/registry/editgrid/index.stories.ts
@@ -69,6 +69,35 @@ export const MinimalConfiguration: Story = {
   },
 };
 
+export const WithTooltip: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'editgrid',
+      key: 'editgrid',
+      label: 'Repeating group',
+      tooltip: 'Surprise!',
+      disableAddingRemovingRows: false,
+      groupLabel: 'Nested item',
+      components: [
+        {
+          id: 'component2',
+          type: 'textfield',
+          key: 'my.textfield',
+          label: 'A simple textfield',
+        },
+      ],
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        editgrid: [{my: {textfield: ''}}],
+      },
+    },
+  },
+};
+
 export const WithValidationSchema: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/editgrid/index.tsx
+++ b/src/registry/editgrid/index.tsx
@@ -60,6 +60,7 @@ export const EditGrid: React.FC<EditGridProps> = ({
     components,
     label,
     hideLabel,
+    tooltip,
     description,
     validate,
     disableAddingRemovingRows,
@@ -85,6 +86,7 @@ export const EditGrid: React.FC<EditGridProps> = ({
     <EditGridField<JSONObject>
       name={key}
       label={hideLabel ? null : label}
+      tooltip={tooltip}
       isRequired={validate?.required}
       description={description}
       enableIsolation

--- a/src/registry/email/index.stories.tsx
+++ b/src/registry/email/index.stories.tsx
@@ -22,10 +22,9 @@ export const MinimalConfiguration: Story = {
     componentDefinition: {
       id: 'component1',
       type: 'email',
+      validateOn: 'blur', // ignored but required in the types
       key: 'my.email',
       label: 'Your email',
-      // TODO: implement!
-      validateOn: 'blur',
     },
   },
   parameters: {
@@ -44,11 +43,30 @@ export const WithPlaceholder: Story = {
     componentDefinition: {
       id: 'component1',
       type: 'email',
+      validateOn: 'blur', // ignored but required in the types
       key: 'email',
       label: 'Your email',
-      // TODO: implement!
-      validateOn: 'blur',
       placeholder: 'geralt@kaer.moh.en',
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        email: '',
+      },
+    },
+  },
+};
+
+export const WithTooltip: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'email',
+      validateOn: 'blur', // ignored but required in the types
+      key: 'email',
+      label: 'Your email',
+      tooltip: 'Surprise!',
     },
   },
   parameters: {
@@ -65,10 +83,9 @@ export const WithAutoComplete: Story = {
     componentDefinition: {
       id: 'component1',
       type: 'email',
+      validateOn: 'blur', // ignored but required in the types
       key: 'email',
       label: 'Your email',
-      // TODO: implement!
-      validateOn: 'blur',
       autocomplete: 'email',
     },
   },
@@ -104,10 +121,9 @@ export const ValidateEmailFormat: ValidationStory = {
     componentDefinition: {
       id: 'component1',
       type: 'email',
+      validateOn: 'blur', // ignored but required in the types
       key: 'my.email',
       label: 'Your email',
-      // TODO: implement or just ignore it?
-      validateOn: 'blur',
     },
   },
   play: async ({canvasElement}) => {
@@ -128,10 +144,9 @@ export const ValidateEmailRequired: ValidationStory = {
     componentDefinition: {
       id: 'component1',
       type: 'email',
+      validateOn: 'blur', // ignored but required in the types
       key: 'my.email',
       label: 'Your email',
-      // TODO: implement or just ignore it?
-      validateOn: 'blur',
       validate: {
         required: true,
       },
@@ -155,10 +170,9 @@ export const PassesAllValidations: ValidationStory = {
     componentDefinition: {
       id: 'component1',
       type: 'email',
+      validateOn: 'blur', // ignored but required in the types
       key: 'my.email',
       label: 'Your email',
-      // TODO: implement or just ignore it?
-      validateOn: 'blur',
       validate: {
         required: true,
       },

--- a/src/registry/email/index.tsx
+++ b/src/registry/email/index.tsx
@@ -12,7 +12,7 @@ export interface FormioEmailProps {
 }
 
 export const FormioEmail: React.FC<FormioEmailProps> = ({
-  componentDefinition: {key, label, description, placeholder, validate, autocomplete},
+  componentDefinition: {key, label, description, tooltip, placeholder, validate, autocomplete},
 }) => {
   return (
     <TextField
@@ -20,6 +20,7 @@ export const FormioEmail: React.FC<FormioEmailProps> = ({
       type="email"
       label={label}
       description={description}
+      tooltip={tooltip}
       isRequired={validate?.required}
       placeholder={placeholder}
       autoComplete={autocomplete}

--- a/src/registry/fieldset/Fieldset.scss
+++ b/src/registry/fieldset/Fieldset.scss
@@ -24,5 +24,19 @@
     font-weight: 400;
     letter-spacing: normal;
     line-height: 1.333;
+
+    @include bem.modifier('tooltip') {
+      // See src/components/forms/Tooltip.scss - over time this custom component will be
+      // replaced with the utrecht-fieldset component.
+      display: flex;
+      align-items: var(--of-utrecht-form-field-label-tooltip-align-items, center);
+      column-gap: var(--of-utrecht-form-field-label-tooltip-column-gap, 4px);
+
+      // prevent the tooltip from taking the same color as the legend itself, but
+      // allow overrides via --of-tooltip-color
+      .openforms-tooltip {
+        color: var(--utrecht-document-color, var(--utrecht-form-label-color));
+      }
+    }
   }
 }

--- a/src/registry/fieldset/index.stories.ts
+++ b/src/registry/fieldset/index.stories.ts
@@ -49,6 +49,36 @@ export const MinimalConfiguration: Story = {
   },
 };
 
+export const WithTooltip: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'fieldset',
+      key: 'fieldset',
+      label: 'Fieldset label',
+      tooltip: 'Surprise!',
+      hideHeader: false,
+      components: [
+        {
+          id: 'component2',
+          type: 'textfield',
+          key: 'my.textfield',
+          label: 'A simple textfield',
+        },
+      ],
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          textfield: '',
+        },
+      },
+    },
+  },
+};
+
 interface ValidationStoryArgs {
   nestedComponents: AnyComponentSchema[];
   onSubmit: FormioFormProps['onSubmit'];

--- a/src/registry/fieldset/index.tsx
+++ b/src/registry/fieldset/index.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 
 import FormFieldContainer from '@/components/FormFieldContainer';
 import type {FormioComponentProps} from '@/components/FormioComponent';
+import Tooltip from '@/components/forms/Tooltip';
 import type {RegistryEntry} from '@/registry/types';
 
 import './Fieldset.scss';
@@ -16,13 +17,21 @@ export interface FieldsetProps {
 }
 
 export const Fieldset: React.FC<FieldsetProps> = ({
-  // TODO: display tooltip, if specified
-  componentDefinition: {components, hideHeader = false, label},
+  componentDefinition: {components, hideHeader = false, label, tooltip},
   renderNested: FormioComponent,
 }) => {
   return (
     <fieldset className={clsx('openforms-fieldset', {'openforms-fieldset--no-header': hideHeader})}>
-      {!hideHeader && label && <legend className="openforms-fieldset__legend">{label}</legend>}
+      {!hideHeader && label && (
+        <legend
+          className={clsx('openforms-fieldset__legend', {
+            'openforms-fieldset__legend--tooltip': !!tooltip,
+          })}
+        >
+          {label}
+          {tooltip && <Tooltip>{tooltip}</Tooltip>}
+        </legend>
+      )}
       <FormFieldContainer>
         {components.map(nestedDefinition => (
           <FormioComponent key={nestedDefinition.id} componentDefinition={nestedDefinition} />

--- a/src/registry/phoneNumber/index.stories.tsx
+++ b/src/registry/phoneNumber/index.stories.tsx
@@ -58,6 +58,26 @@ export const WithPlaceholder: Story = {
   },
 };
 
+export const WithTooltip: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'phoneNumber',
+      key: 'phoneNumber',
+      label: 'A simple phone number',
+      tooltip: 'Surprise!',
+      inputMask: null,
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        phoneNumber: '',
+      },
+    },
+  },
+};
+
 export const WithAutocomplete: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/phoneNumber/index.tsx
+++ b/src/registry/phoneNumber/index.tsx
@@ -20,13 +20,14 @@ export interface PhoneNumberFieldProps {
  * validators.
  */
 export const PhoneNumberField: React.FC<PhoneNumberFieldProps> = ({
-  componentDefinition: {key, label, description, placeholder, validate, autocomplete},
+  componentDefinition: {key, label, description, tooltip, placeholder, validate, autocomplete},
 }) => {
   return (
     <TextField
       name={key}
       label={label}
       description={description}
+      tooltip={tooltip}
       isRequired={validate?.required}
       placeholder={placeholder}
       pattern="^[+0-9][\- 0-9]+$"

--- a/src/registry/radio/index.stories.tsx
+++ b/src/registry/radio/index.stories.tsx
@@ -56,6 +56,40 @@ export const MinimalConfiguration: Story = {
   },
 };
 
+export const WithTooltip: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'radio',
+      key: 'my.radio',
+      label: 'A radio choice',
+      tooltip: 'Surprise!',
+      description: 'A description',
+      values: [
+        {
+          value: 'terra',
+          label: 'Terra',
+        },
+        {
+          value: 'ziggy',
+          label: 'Ziggy',
+        },
+      ],
+      defaultValue: null,
+      ...extensionBoilerplate,
+    } satisfies ManualRadioValuesSchema,
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          radio: null,
+        },
+      },
+    },
+  },
+};
+
 interface ValidationStoryArgs {
   componentDefinition: ManualRadioValuesSchema;
   onSubmit: FormioFormProps['onSubmit'];

--- a/src/registry/radio/index.tsx
+++ b/src/registry/radio/index.tsx
@@ -14,12 +14,13 @@ export interface FormioRadioFieldProps {
 
 export const FormioRadioField: React.FC<FormioRadioFieldProps> = ({componentDefinition}) => {
   assertManualValues(componentDefinition);
-  const {key, label, description, validate = {}, values} = componentDefinition;
+  const {key, label, tooltip, description, validate = {}, values} = componentDefinition;
   const {required = false} = validate;
   return (
     <RadioField
       name={key}
       label={label}
+      tooltip={tooltip}
       description={description}
       isRequired={required}
       options={values}

--- a/src/registry/textfield/index.stories.tsx
+++ b/src/registry/textfield/index.stories.tsx
@@ -56,6 +56,27 @@ export const WithPlaceholder: Story = {
   },
 };
 
+export const WithTooltip: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'textfield',
+      key: 'my.textfield',
+      label: 'A simple textfield',
+      tooltip: 'Surprise!',
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          textfield: '',
+        },
+      },
+    },
+  },
+};
+
 interface ValidationStoryArgs {
   componentDefinition: TextFieldComponentSchema;
   onSubmit: FormioFormProps['onSubmit'];

--- a/src/registry/textfield/index.tsx
+++ b/src/registry/textfield/index.tsx
@@ -12,12 +12,13 @@ export interface FormioTextFieldProps {
 }
 
 export const FormioTextField: React.FC<FormioTextFieldProps> = ({
-  componentDefinition: {key, label, description, placeholder, validate},
+  componentDefinition: {key, label, description, tooltip, placeholder, validate},
 }) => {
   return (
     <TextField
       name={key}
       label={label}
+      tooltip={tooltip}
       description={description}
       isRequired={validate?.required}
       placeholder={placeholder}


### PR DESCRIPTION
Part of open-formulieren/open-forms#5133, #98 and #36

Extended the registry components that support tooltips and added stories for them.