### PR TITLE
Infinitly rerendering hidden editgrids

### DIFF
--- a/src/components/forms/EditGrid/EditGrid.tsx
+++ b/src/components/forms/EditGrid/EditGrid.tsx
@@ -120,7 +120,7 @@ function EditGrid<T extends {[K in keyof T]: JSONValue} = JSONObject>({
   ...props
 }: EditGridProps<T>) {
   const {getFieldProps, errors, getFieldHelpers} = useFormikContext();
-  const {value: formikItems} = getFieldProps<T[]>(name);
+  const {value: formikItems} = getFieldProps<T[] | undefined>(name);
   const [indexToAutoExpand, setIndexToAutoExpand] = useState<number | null>(null);
   return (
     <FormField type="editgrid" className="utrecht-form-field--openforms">
@@ -134,7 +134,7 @@ function EditGrid<T extends {[K in keyof T]: JSONValue} = JSONObject>({
           <div className="openforms-editgrid">
             {/* Render each item wrapped in an EditGridItem */}
             <ol className="openforms-editgrid__container">
-              {formikItems.map((values, index) =>
+              {formikItems?.map((values, index) =>
                 props.enableIsolation ? (
                   <EditGridItem<T>
                     key={index}
@@ -180,7 +180,9 @@ function EditGrid<T extends {[K in keyof T]: JSONValue} = JSONObject>({
                 <PrimaryActionButton
                   type="button"
                   onClick={() => {
-                    setIndexToAutoExpand(formikItems.length);
+                    if (formikItems) {
+                      setIndexToAutoExpand(formikItems.length);
+                    }
                     arrayHelpers.push(emptyItem);
                   }}
                 >

--- a/src/registry/editgrid/visibility.ts
+++ b/src/registry/editgrid/visibility.ts
@@ -17,7 +17,15 @@ const applyVisibility: ApplyVisibility<EditGridComponentSchema> = (
   // ensure we keep adding to the parent scope in case of nested edit grids
   const outerGetEvaluationScope = context?.getEvaluationScope ?? ((v: JSONObject): JSONObject => v);
 
-  let items: JSONObject[] = getIn(values, key) ?? [];
+  let items: JSONObject[] | undefined = getIn(values, key);
+  // Make sure `clearOnHide` actually clears the edit-grid
+  if (items === undefined) {
+    return {
+      updatedDefinition: componentDefinition,
+      updatedValues: values,
+    };
+  }
+
   for (let index: number = 0; index < items.length; index++) {
     const itemValues = items[index];
 


### PR DESCRIPTION
Closes #141 

The editgrids would cause infinite rerenders because the global `processVisibility` and the editgrid `applyVisibility` both updated the data for hidden editgrids differently, causing the results to be different, which in turn caused new rendering/calculations.

By making sure that `applyVisibility` doesn't wrongly resets the data of hidden editgrids, we prevent inconsistent result data and infinite reloads. This also "fixes" the usage of `clearOnHide` for editgrids, as it previously always retained a empty array value.