### PR TITLE
Add currency component

### DIFF
--- a/src/components/forms/NumberField/NumberField.spec.ts
+++ b/src/components/forms/NumberField/NumberField.spec.ts
@@ -1,42 +1,12 @@
 import {expect, test} from 'vitest';
 
-import {Separators, convertToNumber, getSeparators} from './NumberField';
+import {Separators, getSeparators} from './NumberField';
 
 test.each([
   ['nl', {decimalSeparator: ',', thousandSeparator: '.'}],
   ['en', {decimalSeparator: '.', thousandSeparator: ','}],
 ] satisfies [string, Separators][])('%s locale separators: %s', (locale, expected) => {
   const result = getSeparators(locale);
-
-  expect(result).toStrictEqual(expected);
-});
-
-// Dutch
-test.each([
-  ['1', 1],
-  ['1,5', 1.5],
-  ['1000', 1000],
-  ['1000,5', 1000.5],
-  ['1.000,5', 1000.5],
-  ['1,000.5', 1.0005],
-  ['', null],
-] satisfies [string, number | null][])('Dutch locale conversion: %s -> %s', (value, expected) => {
-  const result = convertToNumber(value, 'nl');
-
-  expect(result).toStrictEqual(expected);
-});
-
-// English
-test.each([
-  ['1', 1],
-  ['1.5', 1.5],
-  ['1000', 1000],
-  ['1000.5', 1000.5],
-  ['1,000.5', 1000.5],
-  ['1.000,5', 1.0005],
-  ['', null],
-] satisfies [string, number | null][])('English locale conversion: %s -> %s', (value, expected) => {
-  const result = convertToNumber(value, 'en');
 
   expect(result).toStrictEqual(expected);
 });

--- a/src/components/forms/NumberField/NumberField.stories.ts
+++ b/src/components/forms/NumberField/NumberField.stories.ts
@@ -35,11 +35,11 @@ export const Default: Story = {
     // Assert that clicking on the label focuses the input
     const label = canvas.getByText('Number');
     await userEvent.click(label);
-    await expect(canvas.getByRole('textbox')).toHaveFocus();
+    expect(canvas.getByRole('textbox')).toHaveFocus();
 
     // Assert that you are not able to type letters
     await userEvent.type(input, 'foo');
-    await expect(input).toHaveDisplayValue('');
+    expect(input).toHaveDisplayValue('');
   },
 };
 
@@ -82,12 +82,12 @@ export const LocalisedWithDecimals: Story = {
     const input = canvas.getByLabelText('Number');
 
     // Assert that you're able to provide a decimal number
-    await expect(input).toHaveDisplayValue('1,5');
+    expect(input).toHaveDisplayValue('1,5');
 
     // Assert that you're able to provide a decimal number with comma
     await userEvent.clear(input);
     await userEvent.type(input, '2,3');
-    await expect(input).toHaveDisplayValue('2,3');
+    expect(input).toHaveDisplayValue('2,3');
   },
 };
 
@@ -110,7 +110,7 @@ export const LocalisedWithThousandSeparator: Story = {
     // Assert that you're able to provide a large number, formatted with a Dutch thousand separator
     await userEvent.clear(input);
     await userEvent.type(input, '10000');
-    await expect(input).toHaveDisplayValue('10.000');
+    expect(input).toHaveDisplayValue('10.000');
   },
 };
 
@@ -127,7 +127,7 @@ export const DecimalLimit: Story = {
 
     await userEvent.clear(input);
     await userEvent.type(input, '10.12345');
-    await expect(input).toHaveDisplayValue('10.123');
+    expect(input).toHaveDisplayValue('10.123');
   },
 };
 
@@ -144,7 +144,7 @@ export const NegativeValueNotAllowed: Story = {
     // Assert negative input not possible
     await userEvent.clear(input);
     await userEvent.type(input, '-10');
-    await expect(input).toHaveDisplayValue('10');
+    expect(input).toHaveDisplayValue('10');
   },
 };
 
@@ -161,7 +161,7 @@ export const NegativeValueAllowed: Story = {
     // Assert negative input allowed
     await userEvent.clear(input);
     await userEvent.type(input, '-10');
-    await expect(input).toHaveDisplayValue('-10');
+    expect(input).toHaveDisplayValue('-10');
   },
 };
 
@@ -204,7 +204,7 @@ export const ValidationError: Story = {
   },
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByText('invalid')).toBeVisible();
+    expect(canvas.getByText('invalid')).toBeVisible();
   },
 };
 

--- a/src/components/forms/NumberField/NumberField.stories.ts
+++ b/src/components/forms/NumberField/NumberField.stories.ts
@@ -181,6 +181,48 @@ export const WithPrefixAndSuffix: Story = {
   },
 };
 
+export const WithValuePrefixAndValueSuffix: Story = {
+  args: {
+    name: 'number',
+    label: 'Number',
+    valuePrefix: '$',
+    valueSuffix: '%',
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        number: 123,
+      },
+    },
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    const number = canvas.getByLabelText('Number');
+    expect(number).toHaveDisplayValue('$123%');
+  },
+};
+
+export const WithFixedNumberOfDecimals: Story = {
+  args: {
+    name: 'number',
+    label: 'Number',
+    fixedDecimalScale: true,
+    decimalLimit: 4,
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        number: 10,
+      },
+    },
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    const number = canvas.getByLabelText('Number');
+    expect(number).toHaveDisplayValue('10.0000');
+  },
+};
+
 export const ValidationError: Story = {
   parameters: {
     formik: {

--- a/src/components/forms/NumberField/NumberField.tsx
+++ b/src/components/forms/NumberField/NumberField.tsx
@@ -67,10 +67,25 @@ export interface NumberFieldProps {
    */
   suffix?: string;
   /**
+   * Indicator that describes the field value. It is placed before the value
+   * inside the input field.
+   */
+  valuePrefix?: string;
+  /**
+   * Indicator that describes the field value. It is placed after the value
+   * inside the input field.
+   */
+  valueSuffix?: string;
+  /**
    * Whether to format the number with a thousand separator. Which separator to use
    * will be determined based on the locale.
    */
   useThousandSeparator?: boolean;
+  /**
+   * Whether to format the value with a fixed number of decimals - equal to the value
+   * passed to the decimalLimit property.
+   */
+  fixedDecimalScale?: boolean;
 }
 
 export interface Separators {
@@ -102,7 +117,10 @@ const NumberField: React.FC<NumberFieldProps> = ({
   allowNegative = false,
   prefix,
   suffix,
+  valuePrefix,
+  valueSuffix,
   useThousandSeparator = false,
+  fixedDecimalScale = false,
   ...extraProps
 }) => {
   const {validateField} = useFormikContext();
@@ -155,6 +173,9 @@ const NumberField: React.FC<NumberFieldProps> = ({
           valueIsNumericString={valueIsNumericString}
           customInput={Textbox}
           aria-describedby={errorMessageId}
+          prefix={valuePrefix}
+          suffix={valueSuffix}
+          fixedDecimalScale={fixedDecimalScale}
           {...extraProps}
         />
       </InputContainer>

--- a/src/registry/currency/ValueDisplay.tsx
+++ b/src/registry/currency/ValueDisplay.tsx
@@ -1,0 +1,24 @@
+import type {CurrencyComponentSchema} from '@open-formulieren/types';
+import {FormattedNumber} from 'react-intl';
+
+export interface ValueDisplayProps {
+  componentDefinition: CurrencyComponentSchema;
+  value: number | null;
+}
+
+const ValueDisplay: React.FC<ValueDisplayProps> = ({
+  componentDefinition: {currency, decimalLimit},
+  value,
+}) => {
+  if (value === null) return '';
+  return (
+    <FormattedNumber
+      value={value}
+      maximumFractionDigits={decimalLimit ?? 2}
+      style="currency"
+      currency={currency}
+    />
+  );
+};
+
+export default ValueDisplay;

--- a/src/registry/currency/index.spec.ts
+++ b/src/registry/currency/index.spec.ts
@@ -1,0 +1,12 @@
+import {expect, test} from 'vitest';
+
+import {getCurrencySymbol} from './index';
+
+test.each([
+  ['nl', '€\u00A0'], // includes a non-breaking space
+  ['en', '€'],
+] satisfies [string, string][])('%s locale currency symbol: %s', (locale, expected) => {
+  const result = getCurrencySymbol('EUR', locale);
+
+  expect(result).toStrictEqual(expected);
+});

--- a/src/registry/currency/index.stories.tsx
+++ b/src/registry/currency/index.stories.tsx
@@ -1,0 +1,312 @@
+import type {CurrencyComponentSchema} from '@open-formulieren/types';
+import type {Meta, StoryObj} from '@storybook/react';
+import {expect, fn, userEvent, within} from 'storybook/test';
+
+import type {FormioFormProps} from '@/components/FormioForm';
+import {renderComponentInForm} from '@/registry/storybook-helpers';
+import {withFormik} from '@/sb-decorators';
+
+import ValueDisplay from './ValueDisplay';
+import {FormioCurrencyField as Currency} from './index';
+
+export default {
+  title: 'Component registry / basic / currency',
+  component: Currency,
+  decorators: [withFormik],
+  globals: {
+    locale: 'nl',
+  },
+} satisfies Meta<typeof Currency>;
+
+type Story = StoryObj<typeof Currency>;
+
+export const MinimalConfiguration: Story = {
+  args: {
+    componentDefinition: {
+      id: 'currency',
+      type: 'currency',
+      key: 'currency',
+      label: 'Currency',
+      currency: 'EUR',
+      validateOn: 'blur',
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        currency: 12.34,
+      },
+    },
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const numberField = canvas.getByLabelText('Currency');
+    // Formatted using a non-breaking space
+    expect(numberField).toHaveDisplayValue('€\u00A012,34');
+  },
+};
+
+export const MinimalConfigurationWithEnglishLocale: Story = {
+  args: {
+    componentDefinition: {
+      id: 'currency',
+      type: 'currency',
+      key: 'currency',
+      label: 'Currency',
+      currency: 'EUR',
+      validateOn: 'blur',
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        currency: 12.34,
+      },
+    },
+  },
+  globals: {
+    locale: 'en',
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const numberField = canvas.getByLabelText('Currency');
+    expect(numberField).toHaveDisplayValue('€12.34');
+  },
+};
+
+export const WithTooltip: Story = {
+  args: {
+    componentDefinition: {
+      id: 'currency',
+      type: 'currency',
+      key: 'currency',
+      label: 'Currency',
+      currency: 'EUR',
+      validateOn: 'blur',
+      description: 'A description',
+      tooltip: 'A tooltip',
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        currency: null,
+      },
+    },
+  },
+};
+
+export const AdditionalConfiguration: Story = {
+  args: {
+    componentDefinition: {
+      id: 'currency',
+      type: 'currency',
+      key: 'currency',
+      label: 'Currency',
+      currency: 'EUR',
+      validateOn: 'blur',
+      allowNegative: true,
+      decimalLimit: 3,
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        currency: -10.12345,
+      },
+    },
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const numberField = canvas.getByLabelText('Currency');
+    expect(numberField).toHaveDisplayValue('-€\u00A010,123');
+  },
+};
+
+interface ValidationStoryArgs {
+  componentDefinition: CurrencyComponentSchema;
+  onSubmit: FormioFormProps['onSubmit'];
+}
+
+type ValidationStory = StoryObj<ValidationStoryArgs>;
+
+const BaseValidationStory: ValidationStory = {
+  render: renderComponentInForm,
+  parameters: {
+    formik: {
+      disable: true,
+    },
+  },
+};
+
+export const ValidateRequired: ValidationStory = {
+  ...BaseValidationStory,
+  args: {
+    onSubmit: fn(),
+    componentDefinition: {
+      id: 'currency',
+      type: 'currency',
+      key: 'currency',
+      label: 'Currency',
+      currency: 'EUR',
+      validate: {
+        required: true,
+      },
+      validateOn: 'blur',
+    },
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const currencyField = canvas.getByLabelText('Currency');
+    expect(currencyField).toBeVisible();
+
+    await userEvent.click(canvas.getByRole('button', {name: 'Submit'}));
+    expect(await canvas.findByText('Required')).toBeVisible();
+  },
+};
+
+export const ValidateMax: ValidationStory = {
+  ...BaseValidationStory,
+  args: {
+    onSubmit: fn(),
+    componentDefinition: {
+      id: 'currency',
+      type: 'currency',
+      key: 'currency',
+      label: 'Currency',
+      currency: 'EUR',
+      validate: {
+        max: 10,
+      },
+      validateOn: 'blur',
+    },
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const currencyField = canvas.getByLabelText('Currency');
+    const submit = canvas.getByRole('button', {name: 'Submit'});
+
+    // Assert that value lower than max is fine
+    await userEvent.type(currencyField, '9,1');
+    await userEvent.click(submit);
+    expect(await canvas.queryByText('The value must be € 10,00 or less.')).toBeNull();
+
+    // Assert that value equal to max is fine
+    await userEvent.clear(currencyField);
+    await userEvent.type(currencyField, '10');
+    await userEvent.click(submit);
+    expect(await canvas.queryByText('The value must be € 10,00 or less.')).toBeNull();
+
+    // Assert that value greater than max is not fine
+    await userEvent.clear(currencyField);
+    await userEvent.type(currencyField, '10,5');
+    await userEvent.click(submit);
+    expect(await canvas.findByText('The value must be € 10,00 or less.')).toBeVisible();
+  },
+};
+
+export const ValidateMin: ValidationStory = {
+  ...BaseValidationStory,
+  args: {
+    onSubmit: fn(),
+    componentDefinition: {
+      id: 'currency',
+      type: 'currency',
+      key: 'currency',
+      label: 'Currency',
+      currency: 'EUR',
+      validate: {
+        min: 10,
+      },
+      validateOn: 'blur',
+    },
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const currencyField = canvas.getByLabelText('Currency');
+    const submit = canvas.getByRole('button', {name: 'Submit'});
+
+    // Assert that value greater than min is fine
+    await userEvent.type(currencyField, '11,1');
+    await userEvent.click(submit);
+    expect(await canvas.queryByText('The value must be € 10,00 or greater.')).toBeNull();
+
+    // Assert that value equal to min is fine
+    await userEvent.clear(currencyField);
+    await userEvent.type(currencyField, '10');
+    await userEvent.click(submit);
+    expect(await canvas.queryByText('The value must be € 10,00 or greater.')).toBeNull();
+
+    // Assert that value less than min is not fine
+    await userEvent.clear(currencyField);
+    await userEvent.type(currencyField, '9,1');
+    await userEvent.click(submit);
+    expect(await canvas.findByText('The value must be € 10,00 or greater.')).toBeVisible();
+  },
+};
+
+interface ValueDisplayStoryArgs {
+  componentDefinition: CurrencyComponentSchema;
+  value: number;
+}
+
+type ValueDisplayStory = StoryObj<ValueDisplayStoryArgs>;
+
+const BaseValueDisplayStory: ValueDisplayStory = {
+  render: args => <ValueDisplay {...args} />,
+  parameters: {
+    formik: {
+      disable: true,
+    },
+  },
+};
+
+export const SingleValueDisplay: ValueDisplayStory = {
+  ...BaseValueDisplayStory,
+  args: {
+    componentDefinition: {
+      id: 'currency',
+      type: 'currency',
+      key: 'currency',
+      label: 'currency',
+      currency: 'EUR',
+      validateOn: 'blur',
+    },
+    value: 12.34,
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    expect(canvas.getByText('€ 12,34')).toBeInTheDocument();
+  },
+};
+
+export const SingleValueDisplayWithEnglishLocale: ValueDisplayStory = {
+  ...BaseValueDisplayStory,
+  args: {
+    componentDefinition: {
+      id: 'currency',
+      type: 'currency',
+      key: 'currency',
+      label: 'currency',
+      currency: 'EUR',
+      validateOn: 'blur',
+      decimalLimit: 3,
+    },
+    value: 12.3456,
+  },
+  globals: {
+    locale: 'en',
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    expect(canvas.getByText('€12.346')).toBeInTheDocument();
+  },
+};

--- a/src/registry/currency/index.tsx
+++ b/src/registry/currency/index.tsx
@@ -1,0 +1,72 @@
+import type {CurrencyComponentSchema} from '@open-formulieren/types';
+import {useIntl} from 'react-intl';
+
+import NumberField from '@/components/forms/NumberField';
+import type {RegistryEntry} from '@/registry/types';
+
+import ValueDisplay from './ValueDisplay';
+import getInitialValues from './initialValues';
+import getValidationSchema from './validationSchema';
+
+export const getCurrencySymbol = (currency: string, locale: string): string => {
+  const numberFormat = new Intl.NumberFormat(locale, {style: 'currency', currency});
+
+  // We get the currency symbol by formatting an arbitrary number and extracting it from the parts
+  const parts = numberFormat.formatToParts(1.0);
+
+  // All the part values before the 1 are combined to include (possible) spaces.
+  // Note that this assumes that the currency symbol is in front of the value, which is true
+  // for the locales that we currently support (Dutch and English).
+  const stopIndex = parts.findIndex(part => part.value === '1');
+  return parts
+    .slice(0, stopIndex)
+    .map(part => part.value)
+    .join('');
+};
+
+export interface FormioCurrencyFieldProps {
+  componentDefinition: CurrencyComponentSchema;
+}
+
+export const FormioCurrencyField: React.FC<FormioCurrencyFieldProps> = ({
+  componentDefinition: {
+    key,
+    label,
+    description,
+    tooltip,
+    validate,
+    currency,
+    decimalLimit = 2,
+    allowNegative,
+    disabled: isReadonly,
+  },
+}) => {
+  const {locale} = useIntl();
+
+  const currencySymbol = getCurrencySymbol(currency, locale);
+
+  return (
+    <NumberField
+      name={key}
+      label={label}
+      tooltip={tooltip}
+      description={description}
+      isRequired={validate?.required}
+      decimalLimit={decimalLimit}
+      allowNegative={allowNegative}
+      isReadonly={isReadonly}
+      valuePrefix={currencySymbol}
+      useThousandSeparator
+      fixedDecimalScale
+    />
+  );
+};
+
+const CurrencyFieldComponent: RegistryEntry<CurrencyComponentSchema> = {
+  formField: FormioCurrencyField,
+  valueDisplay: ValueDisplay,
+  getInitialValues,
+  getValidationSchema,
+};
+
+export default CurrencyFieldComponent;

--- a/src/registry/currency/initialValues.ts
+++ b/src/registry/currency/initialValues.ts
@@ -1,0 +1,16 @@
+import type {CurrencyComponentSchema} from '@open-formulieren/types';
+
+import type {GetInitialValues} from '@/registry/types';
+
+const getInitialValues: GetInitialValues<CurrencyComponentSchema, number | null> = ({
+  key,
+  defaultValue,
+}: CurrencyComponentSchema) => {
+  // if no default value is explicitly specified, return the empty value
+  if (defaultValue === undefined) {
+    defaultValue = null;
+  }
+  return {[key]: defaultValue};
+};
+
+export default getInitialValues;

--- a/src/registry/currency/validationSchema.spec.ts
+++ b/src/registry/currency/validationSchema.spec.ts
@@ -1,0 +1,63 @@
+import type {CurrencyComponentSchema} from '@open-formulieren/types';
+import {createIntl} from 'react-intl';
+import {describe, expect, test} from 'vitest';
+
+import {getRegistryEntry} from '@/registry/registry';
+
+import getValidationSchema from './validationSchema';
+
+const intl = createIntl({locale: 'en', messages: {}});
+
+const BASE_COMPONENT: CurrencyComponentSchema = {
+  type: 'currency',
+  id: 'currency',
+  key: 'currency',
+  currency: 'EUR',
+  label: 'Currency',
+  validateOn: 'blur',
+  validate: {
+    min: 5,
+    max: 10,
+  },
+};
+
+const buildValidationSchema = (component: CurrencyComponentSchema) => {
+  const schemas = getValidationSchema(component, intl, getRegistryEntry);
+  return schemas[component.key];
+};
+
+describe('currency component validation', () => {
+  test.each([5, 5.0, 7.5, 10, 10.0])('accepts values inside min-max range (value: %s)', value => {
+    const schema = buildValidationSchema(BASE_COMPONENT);
+
+    const {success} = schema.safeParse(value);
+
+    expect(success).toBe(true);
+  });
+
+  test.each([0, 4.9, 15, 20.1])(
+    'does not accept values outside min-max range (value: %s)',
+    value => {
+      const schema = buildValidationSchema(BASE_COMPONENT);
+
+      const {success} = schema.safeParse(value);
+
+      expect(success).toBe(false);
+    }
+  );
+
+  test.each([
+    [false, null],
+    [true, null],
+  ])('required %s (value: %s)', (required, value) => {
+    const component: CurrencyComponentSchema = {
+      ...BASE_COMPONENT,
+      validate: {...BASE_COMPONENT.validate, required},
+    };
+    const schema = buildValidationSchema(component);
+
+    const {success} = schema.safeParse(value);
+
+    expect(success).toBe(!required);
+  });
+});

--- a/src/registry/currency/validationSchema.ts
+++ b/src/registry/currency/validationSchema.ts
@@ -27,26 +27,16 @@ const getValidationSchema: GetValidationSchema<CurrencyComponentSchema> = (
   const maxFormatted = max && numberFormat.format(max);
   const minFormatted = min && numberFormat.format(min);
 
-  const isLessThanOrEqualToMaximum = (value: number | null): boolean => {
-    if (max === undefined || value === null) return true;
-    return value <= max;
-  };
-
-  const isGreaterThanOrEqualToMinimum = (value: number | null): boolean => {
-    if (min === undefined || value === null) return true;
-    return value >= min;
-  };
-
-  let schema: z.ZodFirstPartySchemaTypes = z
-    .number()
-    .nullable() // null is also a valid value
-    .refine(isLessThanOrEqualToMaximum, {
+  let schema: z.ZodFirstPartySchemaTypes = z.number();
+  if (max !== undefined)
+    schema = schema.lte(max, {
       message: intl.formatMessage(NUMBER_GREATER_THAN_MAX_MESSAGE, {max: maxFormatted}),
-    })
-    .refine(isGreaterThanOrEqualToMinimum, {
+    });
+  if (min !== undefined)
+    schema = schema.gte(min, {
       message: intl.formatMessage(NUMBER_LESS_THAN_MIN_MESSAGE, {min: minFormatted}),
     });
-  if (!required) schema = schema.optional();
+  if (!required) schema = schema.nullable().optional();
 
   // For numbers, a missing value is null, which doesn't trigger the required validation of zod,
   // so we set it to undefined manually

--- a/src/registry/currency/validationSchema.ts
+++ b/src/registry/currency/validationSchema.ts
@@ -1,0 +1,56 @@
+import type {CurrencyComponentSchema} from '@open-formulieren/types';
+import {defineMessage} from 'react-intl';
+import {z} from 'zod';
+
+import type {GetValidationSchema} from '@/registry/types';
+
+const NUMBER_GREATER_THAN_MAX_MESSAGE = defineMessage({
+  description: 'Validation error for number greater than maximum value.',
+  defaultMessage: 'The value must be {max} or less.',
+});
+
+const NUMBER_LESS_THAN_MIN_MESSAGE = defineMessage({
+  description: 'Validation error for number less than minimum value.',
+  defaultMessage: 'The value must be {min} or greater.',
+});
+
+const getValidationSchema: GetValidationSchema<CurrencyComponentSchema> = (
+  componentDefinition,
+  intl
+) => {
+  const {key, validate, currency} = componentDefinition;
+  const required = validate?.required;
+  const max = validate?.max;
+  const min = validate?.min;
+
+  const numberFormat = new Intl.NumberFormat(intl.locale, {style: 'currency', currency});
+  const maxFormatted = max && numberFormat.format(max);
+  const minFormatted = min && numberFormat.format(min);
+
+  const isLessThanOrEqualToMaximum = (value: number | null): boolean => {
+    if (max === undefined || value === null) return true;
+    return value <= max;
+  };
+
+  const isGreaterThanOrEqualToMinimum = (value: number | null): boolean => {
+    if (min === undefined || value === null) return true;
+    return value >= min;
+  };
+
+  let schema: z.ZodFirstPartySchemaTypes = z
+    .number()
+    .nullable() // null is also a valid value
+    .refine(isLessThanOrEqualToMaximum, {
+      message: intl.formatMessage(NUMBER_GREATER_THAN_MAX_MESSAGE, {max: maxFormatted}),
+    })
+    .refine(isGreaterThanOrEqualToMinimum, {
+      message: intl.formatMessage(NUMBER_LESS_THAN_MIN_MESSAGE, {min: minFormatted}),
+    });
+  if (!required) schema = schema.optional();
+
+  // For numbers, a missing value is null, which doesn't trigger the required validation of zod,
+  // so we set it to undefined manually
+  return {[key]: z.preprocess(value => (value === null && required ? undefined : value), schema)};
+};
+
+export default getValidationSchema;

--- a/src/registry/number/index.stories.tsx
+++ b/src/registry/number/index.stories.tsx
@@ -41,7 +41,7 @@ export const MinimalConfiguration: Story = {
     const canvas = within(canvasElement);
 
     const numberField = canvas.getByLabelText('Number');
-    await expect(numberField).toHaveDisplayValue('12,34');
+    expect(numberField).toHaveDisplayValue('12,34');
   },
 };
 
@@ -69,7 +69,7 @@ export const MinimalConfigurationWithEnglishLocale: Story = {
     const canvas = within(canvasElement);
 
     const numberField = canvas.getByLabelText('Number');
-    await expect(numberField).toHaveDisplayValue('12.34');
+    expect(numberField).toHaveDisplayValue('12.34');
   },
 };
 
@@ -118,7 +118,7 @@ export const AdditionalConfiguration: Story = {
     const canvas = within(canvasElement);
 
     const numberField = canvas.getByLabelText('Number');
-    await expect(numberField).toHaveDisplayValue('-10,12');
+    expect(numberField).toHaveDisplayValue('-10,12');
   },
 };
 
@@ -156,8 +156,8 @@ export const ValidateRequired: ValidationStory = {
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
 
-    const textField = canvas.getByLabelText('Number');
-    expect(textField).toBeVisible();
+    const numberField = canvas.getByLabelText('Number');
+    expect(numberField).toBeVisible();
 
     await userEvent.click(canvas.getByRole('button', {name: 'Submit'}));
     expect(await canvas.findByText('Required')).toBeVisible();
@@ -276,7 +276,7 @@ export const SingleValueDisplay: ValueDisplayStory = {
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
 
-    await expect(canvas.getByText('12,3457')).toBeInTheDocument();
+    expect(canvas.getByText('12,3457')).toBeInTheDocument();
   },
 };
 
@@ -299,6 +299,6 @@ export const SingleValueDisplayWithEnglishLocale: ValueDisplayStory = {
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
 
-    await expect(canvas.getByText('12.35')).toBeInTheDocument();
+    expect(canvas.getByText('12.35')).toBeInTheDocument();
   },
 };

--- a/src/registry/number/validationSchema.spec.ts
+++ b/src/registry/number/validationSchema.spec.ts
@@ -26,7 +26,15 @@ const buildValidationSchema = (component: NumberComponentSchema) => {
 };
 
 describe('number component validation', () => {
-  test.each(['0', '4.9', '15', '20.1'])(
+  test.each([5, 5.0, 7.5, 10, 10.0])('accepts values inside min-max range (value: %s)', value => {
+    const schema = buildValidationSchema(BASE_COMPONENT);
+
+    const {success} = schema.safeParse(value);
+
+    expect(success).toBe(true);
+  });
+
+  test.each([0, 4.9, 15, 20.1])(
     'does not accept values outside min-max range (value: %s)',
     value => {
       const schema = buildValidationSchema(BASE_COMPONENT);

--- a/src/registry/number/validationSchema.ts
+++ b/src/registry/number/validationSchema.ts
@@ -23,26 +23,12 @@ const getValidationSchema: GetValidationSchema<NumberComponentSchema> = (
   const max = validate?.max;
   const min = validate?.min;
 
-  const isLessThanOrEqualToMaximum = (value: number | null): boolean => {
-    if (max === undefined || value === null) return true;
-    return value <= max;
-  };
-
-  const isGreaterThanOrEqualToMinimum = (value: number | null): boolean => {
-    if (min === undefined || value === null) return true;
-    return value >= min;
-  };
-
-  let schema: z.ZodFirstPartySchemaTypes = z
-    .number()
-    .nullable() // null is also a valid value
-    .refine(isLessThanOrEqualToMaximum, {
-      message: intl.formatMessage(NUMBER_GREATER_THAN_MAX_MESSAGE, {max}),
-    })
-    .refine(isGreaterThanOrEqualToMinimum, {
-      message: intl.formatMessage(NUMBER_LESS_THAN_MIN_MESSAGE, {min}),
-    });
-  if (!required) schema = schema.optional();
+  let schema: z.ZodFirstPartySchemaTypes = z.number();
+  if (max !== undefined)
+    schema = schema.lte(max, {message: intl.formatMessage(NUMBER_GREATER_THAN_MAX_MESSAGE, {max})});
+  if (min !== undefined)
+    schema = schema.gte(min, {message: intl.formatMessage(NUMBER_LESS_THAN_MIN_MESSAGE, {min})});
+  if (!required) schema = schema.nullable().optional();
 
   // For numbers, a missing value is null, which doesn't trigger the required validation of zod,
   // so we set it to undefined manually

--- a/src/registry/registry.ts
+++ b/src/registry/registry.ts
@@ -4,6 +4,7 @@ import BSN from './bsn';
 import Checkbox from './checkbox';
 import Columns from './columns';
 import Content from './content';
+import Currency from './currency';
 import DateField from './date';
 import EditGrid from './editgrid';
 import Email from './email';
@@ -36,6 +37,7 @@ const REGISTRY: Registry = {
   number: Number,
   checkbox: Checkbox,
   selectboxes: Selectboxes,
+  currency: Currency,
   radio: RadioField,
   // special types
   iban: IBAN,


### PR DESCRIPTION
Closes #81 

Some notes:

* If the `fixedDecimalScale` prop is passed to the `NumericFormat` component, the value will always be formatted with the number of decimals specified in `decimalLimit`. There are two differences in behavior w.r.t. the current situation - how do we feel about this:
   - The values are directly formatted with the specified number of decimals, so no on-blur action
   - If a user wants to remove decimals, they get set to 0 instead of being removed, and the cursor just shifts one place to the left. Not sure about the impact on accessibility. EDIT: the mac OS screen reader reads this out as "selection replacement"

* ~`validate.plugins` is one of the listed requirements in the ticket, but I'm not sure what it does and how it works. I don't see any other components that have implemented this, but currency is not the only relevant one for this feature, right? Perhaps better to create a separate ticket for this?~ It appears there already is: #76 :)

* open-formulieren/open-forms#5274
This described situation is not representative anymore. A default value of 0 will already be formatted with decimals. A value still needs to be selected first, though I think that is fine because it happens for other components as well. 0 is not an empty value, null is.

* open-formulieren/open-forms#2341
I'm not entirely sure what the behaviour will be now. Can it be tested already?
