### PR TITLE
Handle editgrid.defaultValue being `null`

### DIFF
--- a/src/registry/editgrid/index.spec.tsx
+++ b/src/registry/editgrid/index.spec.tsx
@@ -373,3 +373,28 @@ test('Item validation schema adapts to component visibility', async () => {
   expect(await screen.findByText('Invalid')).toBeVisible();
   expect(screen.queryAllByRole('button', {name: 'Save'})).toHaveLength(2);
 });
+
+test('defaultValue: null does not crash', async () => {
+  render(
+    <Form
+      components={[
+        {
+          id: 'editgrid',
+          type: 'editgrid',
+          key: 'editgrid',
+          label: 'Edit grid',
+          groupLabel: 'Item',
+          addAnother: 'Add item',
+          disableAddingRemovingRows: false,
+          components: [],
+          // @ts-expect-error type definitions and actual formio.js builder behaviour don't
+          // match!
+          defaultValue: null,
+        },
+      ]}
+      onSubmit={vi.fn()}
+    />
+  );
+
+  expect(screen.getByRole('button', {name: 'Add item'})).toBeVisible();
+});

--- a/src/registry/editgrid/initialValues.ts
+++ b/src/registry/editgrid/initialValues.ts
@@ -7,6 +7,13 @@ const getInitialValues: GetInitialValues<EditGridComponentSchema, JSONObject[]> 
   key,
   defaultValue = [],
 }: EditGridComponentSchema) => {
+  // For some reason the defaultValue is not properly set to an (empty) array by the
+  // formio.js builder in the backend, so we need to handle this case even though it
+  // should not be possible according to the type definitions.
+  if (defaultValue == null) {
+    defaultValue = [];
+  }
+
   // we just expose the component definition default value. This is not a layout
   // component, so we needn't recurse into the `components` property.
   // FXIME in upstream types repo: instead of `unknown` type, use `JSONObject` since we


### PR DESCRIPTION
Part of open-formulieren/open-forms-sdk#863

The intrinsic value of an editgrid is an array of objects, but something is going wrong in the formio-builder or formio.js layer when an editgrid component is added, leading to defaultValue being initialized to 'null'.

We can detect this in the initial values derivation and normalize it in the renderer, even though it should be fixed in the builder aspect, but that also requires patching up the backend data for existing component definitions.