### PR TITLE
:pencil: Remove outdated comment and fix typo

### DIFF
--- a/src/components/forms/DateTimeField/DateTimeField.tsx
+++ b/src/components/forms/DateTimeField/DateTimeField.tsx
@@ -189,7 +189,6 @@ const DateTimeField: React.FC<DateTimeFieldProps> = ({
 
   // If we have a date object, format it according to the locale (and remove comma) and use as the
   // textbox value. Otherwise, just use the field value directly.
-  // Note: cannot use `timeStyle: 'short'` here, because it will add AM/PM for English locale.
   const textboxValue =
     currentDateTime !== null
       ? formatDate(currentDateTime, {

--- a/src/components/forms/DateTimeField/utils.ts
+++ b/src/components/forms/DateTimeField/utils.ts
@@ -55,7 +55,7 @@ export const parseDateTime = (value: string, meta?: LocaleMeta): Date | null => 
   // Seconds can be missing
   if (!hour || !minute || meta.is24HourFormat == ['AM', 'PM'].includes(dayPeriod)) return null;
   if (!meta.is24HourFormat) {
-    const time12h = parse(`${hour}:${minute} ${dayPeriod}`, 'hh:mmm a', new Date());
+    const time12h = parse(`${hour}:${minute} ${dayPeriod}`, 'hh:mm a', new Date());
     hour = format(time12h, 'H');
   }
 


### PR DESCRIPTION
Note that we still cannot use `timeStyle: 'short'`, as it doesn't work with the separate year, month, and day properties. It does when combined with `dateStyle: 'short'`, but that formats the English dates to 'mm/dd/yy' instead of 'mm/dd/yyyy'