### PR TITLE
:bug: Fix number and currency fields not showing validation errors

### DIFF
--- a/src/components/forms/NumberField/NumberField.tsx
+++ b/src/components/forms/NumberField/NumberField.tsx
@@ -129,7 +129,7 @@ const NumberField: React.FC<NumberFieldProps> = ({
 }) => {
   name = useFieldConfig(name);
   const {validateField} = useFormikContext();
-  // Note that we have a custom onValueChange handler, so `value` and `onBlur` is the only relevant
+  // Note that we have a custom onValueChange handler, so `value` and `onBlur` are the only relevant
   // field input props
   const [{value, onBlur}, {touched}, {setValue}] = useField<number | null>(name);
   const {locale} = useIntl();
@@ -158,6 +158,7 @@ const NumberField: React.FC<NumberFieldProps> = ({
 
       <InputContainer prefix={prefix} suffix={suffix}>
         <NumericFormat
+          name={name}
           value={value}
           onBlur={async e => {
             onBlur(e);


### PR DESCRIPTION
From https://github.com/open-formulieren/open-forms-sdk/issues/863

The `name` property was not passed to `NumericFormat` -> the field name was missing from the event in the `onBlur` handler -> `touched` was not set inside Formik's `onBlur` -> error was not shown.

I'm not entirely sure how `touched` is set in the stories, though, because the errors are shown there :thinking: