### PR TITLE
Non-editable editgrid item in isolation mode

### DIFF
--- a/src/components/forms/EditGrid/EditGrid.stories.tsx
+++ b/src/components/forms/EditGrid/EditGrid.stories.tsx
@@ -185,7 +185,7 @@ export const NonEditableItemInIsolation: Story = {
     emptyItem: undefined,
     // The first item is uneditable, the second item is editable.
     canEditItem: (_, index) => index === 1,
-    validate: () => Promise.resolve(),
+    validate: async () => {},
   },
   parameters: {
     formik: {

--- a/src/components/forms/EditGrid/EditGrid.tsx
+++ b/src/components/forms/EditGrid/EditGrid.tsx
@@ -280,8 +280,8 @@ function IsolatedEditGridItem<T extends {[K in keyof T]: JSONValue} = JSONObject
   // attributes.
   // Only if the item is editable, we need to use the namePrefix X:Y notation.
   // For non-editable items, we don't render a scoped formik form, so X:Y won't be
-  // available. In this case we should use the globally available namePrefix X[Y].
-  const namePrefix = isEditable ? `${name}:${index}` : `${name}[${index}]`;
+  // available. In this case we should use the globally available namePrefix X.Y
+  const namePrefix = isEditable ? `${name}:${index}` : `${name}.${index}`;
   const prefixedData: WrappedItemData<T> = useMemo(() => {
     return setIn({}, namePrefix, values);
   }, [namePrefix, values]);


### PR DESCRIPTION
Partly closes #122

Non-editable editgrid items in isolation mode cannot use `namePrefix` to retrieve their data from the formik context. This is because the `namePrefix` namespace, is the namespace of the isolated formik form state, which isn't available for non-editable editgrid items.

This PR solves this issue by setting the `namePrefix` to the globally available namespace, for non-editable editgrid items. This way, these editgrid items can still retrieve their value from the closest formik state.

For editgrid is this not-yet a problem, as all editgrids are hardcoded to be isolated and always editable. For possible future editgrid features this ensures that same functions of retrieving item values can be used for editable and non-editable items.

Now, for components that use the basic structure of editgrid, this creates possibilities to further control edit permissions. In the case of the children component, this allows the user to select an child (updating a `selected` property) while not being able to change the child data.