### PR TITLE
:package: Export the modal component

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export {default as FormioForm} from '@/components/FormioForm';
 // Low level API
 export * from '@/components/forms';
 export {default as LoadingIndicator} from '@/components/LoadingIndicator';
+export {default as Modal} from '@/components/modal';


### PR DESCRIPTION
So that the SDK can use it to refactor its own modal implementation.