### PR TITLE
[#221] Disable checkboxes when max allowed is reached

### DIFF
--- a/src/components/forms/Checkbox/Checkbox.tsx
+++ b/src/components/forms/Checkbox/Checkbox.tsx
@@ -41,6 +41,10 @@ export interface CheckboxProps {
    */
   isDisabled?: boolean;
   /**
+   * Whether the checkbox should be disabled or not.
+   */
+  disabled?: boolean;
+  /**
    * Additional description displayed close to the field - use this to document any
    * validation requirements that are crucial to successfully submit the form. More
    * information that is contextual/background typically belongs in a tooltip.
@@ -92,6 +96,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
         appearance="custom"
         invalid={invalid}
         aria-describedby={ariaDescribedBy || undefined}
+        disabled={isDisabled}
         {...props}
         onBlur={async e => {
           props.onBlur(e);

--- a/src/registry/selectboxes/index.stories.tsx
+++ b/src/registry/selectboxes/index.stories.tsx
@@ -208,6 +208,40 @@ export const ValidateRequired: ValidationStory = {
     ).toBeVisible();
   },
 };
+
+export const MaxAllowedReached: ValidationStory = {
+  ...BaseValidationStory,
+  args: {
+    onSubmit: fn(),
+    componentDefinition: {
+      id: 'component1',
+      type: 'selectboxes',
+      key: 'my.selectboxes',
+      label: 'A selectboxes field',
+      defaultValue: {option1: false, option2: false, option3: false},
+      values: [
+        {value: 'option1', label: 'Option 1'},
+        {value: 'option2', label: 'Option 2'},
+        {value: 'option3', label: 'Option 3'},
+      ],
+      validate: {
+        maxSelectedCount: 2,
+      },
+      ...extensionBoilerplate,
+    } satisfies ManualSelectboxesValuesSchema,
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByLabelText('Option 1'));
+    await userEvent.click(canvas.getByLabelText('Option 2'));
+
+    expect(canvas.getByLabelText('Option 1')).toBeChecked();
+    expect(canvas.getByLabelText('Option 2')).toBeChecked();
+    expect(canvas.getByLabelText('Option 3')).toBeDisabled();
+  },
+};
+
 export const ValidateRequiredWithCustomErrorMessage: ValidationStory = {
   ...BaseValidationStory,
   args: {
@@ -323,40 +357,6 @@ export const ValidateMinRequiredWithCustomErrorMessage: ValidationStory = {
     await userEvent.click(canvas.getByRole('button', {name: 'Submit'}));
 
     expect(canvas.queryByText('Custom error message for min selected count')).toBeInTheDocument();
-  },
-};
-
-export const ValidateMaxRequiredWithCustomErrorMessage: ValidationStory = {
-  ...BaseValidationStory,
-  args: {
-    onSubmit: fn(),
-    componentDefinition: {
-      id: 'component1',
-      type: 'selectboxes',
-      key: 'my.selectboxes',
-      label: 'A selectboxes field',
-      defaultValue: {option1: false, option2: false},
-      values: [
-        {value: 'option1', label: 'Option 1'},
-        {value: 'option2', label: 'Option 2'},
-      ],
-      validate: {
-        required: false,
-        maxSelectedCount: 1,
-      },
-      errors: {maxSelectedCount: 'Custom error message for max selected count'},
-      ...extensionBoilerplate,
-    } satisfies ManualSelectboxesValuesSchema,
-  },
-
-  play: async ({canvasElement}) => {
-    const canvas = within(canvasElement);
-
-    await userEvent.click(canvas.getByLabelText('Option 1'));
-    await userEvent.click(canvas.getByLabelText('Option 2'));
-    await userEvent.click(canvas.getByRole('button', {name: 'Submit'}));
-
-    expect(canvas.queryByText('Custom error message for max selected count')).toBeInTheDocument();
   },
 };
 


### PR DESCRIPTION
Closes #221

Sometimes it's needed to disable a checkbox for some reason. For example the when a max limit of allowed checked checkboxes is reached we disable the rest of them. The custom error message for the maxSelectedCount has not been removed because we may have an edge case were it will be shown and useful.