### PR TITLE
Profile component initialValues crashes when defaultValue is `null`

### DIFF
--- a/src/registry/customerProfile/initialValues.spec.ts
+++ b/src/registry/customerProfile/initialValues.spec.ts
@@ -32,3 +32,37 @@ test('initialValues should return digital addresses for each supported digital a
     ],
   });
 });
+
+/**
+ * The initialValues function should accept the defaultValue `null`.
+ * `null` isn't allowed by the type definition, but its the empty value returned by formio.
+ */
+test('initialValues should accept defaultValue of `null`', () => {
+  const component: CustomerProfileComponentSchema = {
+    type: 'customerProfile',
+    id: 'customerProfile',
+    key: 'customerProfile',
+    label: 'customerProfile',
+    // @ts-expect-error null isn't allowed by the TypeScript definition,
+    // but is the defaultValue that's set by formio.
+    defaultValue: null,
+    shouldUpdateCustomerData: false,
+    digitalAddressTypes: ['email', 'phoneNumber'],
+  };
+
+  const initialValues = getInitialValues(component, getRegistryEntry);
+  expect(initialValues).toEqual({
+    customerProfile: [
+      {
+        type: 'email',
+        address: '',
+        preferenceUpdate: 'useOnlyOnce',
+      },
+      {
+        type: 'phoneNumber',
+        address: '',
+        preferenceUpdate: 'useOnlyOnce',
+      },
+    ],
+  });
+});

--- a/src/registry/customerProfile/initialValues.ts
+++ b/src/registry/customerProfile/initialValues.ts
@@ -23,11 +23,14 @@ const getInitialValues: GetInitialValues<
   defaultValue = [] satisfies CustomerProfileData,
   digitalAddressTypes,
 }: CustomerProfileComponentSchema) => {
-  // side-effect of the generic types in formio components, but realistically we don't
-  // expect any defaultValue to ever be set.
-  assertNotArrayOfArray(defaultValue);
+  // Only validate when the value is non-null
+  if (defaultValue != null) {
+    // side-effect of the generic types in formio components, but realistically we don't
+    // expect any defaultValue to ever be set.
+    assertNotArrayOfArray(defaultValue);
+  }
 
-  if (defaultValue === undefined || !defaultValue?.length) {
+  if (defaultValue == null || !defaultValue?.length) {
     defaultValue = digitalAddressTypes.map(
       type =>
         ({


### PR DESCRIPTION
Closes #178

When creating a new profile component, the defaultValue is set to `null`. The `getInitialValues` doesn't take the defaultValue `null` into account, which results `value.some` being called for the value `null` (which crashes).

To fix the `getInitialValues`, we should only perform the `assertNotArrayOfArray` when the value isn't `null`.