### PR TITLE
[#263] Char count for `textfield` and `textarea` is only displayed when there is a value

### DIFF
--- a/src/components/forms/TextField/TextField.stories.ts
+++ b/src/components/forms/TextField/TextField.stories.ts
@@ -164,6 +164,9 @@ export const ShowCharCountWithoutLimit: Story = {
     const canvas = within(canvasElement);
     const input = await canvas.findByLabelText('Show char count');
 
+    // The character count should not be shown with empty value
+    expect(canvas.queryByText('0 karakters.')).not.toBeInTheDocument();
+
     await userEvent.type(input, 'I am an example text.');
 
     // Expect the 'X characters' text to be shown, with the right amount of used
@@ -202,6 +205,9 @@ export const ShowCharCountWithLimit: Story = {
   play: async ({canvasElement, step}) => {
     const canvas = within(canvasElement);
     const input = await canvas.findByLabelText('Show char count');
+
+    // The character count should not be shown with empty value
+    expect(canvas.queryByText('0 karakters.')).not.toBeInTheDocument();
 
     // The character limit should not be set to the html component.
     // Conform the current setup, we limit the amount of characters via custom validation

--- a/src/components/forms/TextField/TextField.tsx
+++ b/src/components/forms/TextField/TextField.tsx
@@ -132,7 +132,9 @@ const TextField: React.FC<TextFieldProps & TextboxProps> = ({
           {...extraProps}
         />
       </Paragraph>
-      {showCharCount && <CharCount id={characterCountId} text={value} limit={maxLength} />}
+      {showCharCount && (value?.length ?? 0) > 0 && (
+        <CharCount id={characterCountId} text={value} limit={maxLength} />
+      )}
       {children}
       <HelpText>{description}</HelpText>
       {touched && errorMessageId && <ValidationErrors error={error} id={errorMessageId} />}

--- a/src/components/forms/Textarea/Textarea.stories.ts
+++ b/src/components/forms/Textarea/Textarea.stories.ts
@@ -210,6 +210,9 @@ export const ShowCharCountWithoutLimit: Story = {
     const canvas = within(canvasElement);
     const input = await canvas.findByLabelText('Show char count');
 
+    // The character count should not be shown with empty value
+    expect(canvas.queryByText('0 karakters.')).not.toBeInTheDocument();
+
     await userEvent.type(input, 'I am an example text.');
 
     // Expect the 'X characters' text to be shown, with the right amount of used
@@ -248,6 +251,9 @@ export const ShowCharCountWithLimit: Story = {
   play: async ({canvasElement, step}) => {
     const canvas = within(canvasElement);
     const input = await canvas.findByLabelText('Show char count');
+
+    // The character count should not be shown with empty value
+    expect(canvas.queryByText('0 karakters.')).not.toBeInTheDocument();
 
     // The character limit should not be set to the html component.
     // Conform the current setup, we limit the amount of characters via custom validation

--- a/src/components/forms/Textarea/Textarea.tsx
+++ b/src/components/forms/Textarea/Textarea.tsx
@@ -145,7 +145,9 @@ const Textarea: React.FC<TextareaProps & UtrechtTextareaProps> = ({
           {...extraProps}
         />
       </Paragraph>
-      {showCharCount && <CharCount id={characterCountId} text={value} limit={maxLength} />}
+      {showCharCount && (value?.length ?? 0) > 0 && (
+        <CharCount id={characterCountId} text={value} limit={maxLength} />
+      )}
       <HelpText>{description}</HelpText>
       {touched && errorMessageId && <ValidationErrors error={error} id={errorMessageId} />}
     </FormField>


### PR DESCRIPTION
Closes #263