### PR TITLE
:bug: [#5944] Fixing iOS 18 checkbox input not clickable issue

### DIFF
--- a/src/components/forms/Checkbox/Checkbox.scss
+++ b/src/components/forms/Checkbox/Checkbox.scss
@@ -33,6 +33,7 @@
       .utrecht-checkbox--custom {
         margin-block-start: var(--of-utrecht-form-label-checkbox-padding-block-start);
         margin-inline-start: var(--of-utrecht-form-label-checkbox-padding-inline-start);
+        z-index: 0;
 
         &:focus ~ .utrecht-form-field__label--checkbox {
           outline: var(--of-utrecht-form-label-checkbox-focus-within-outline);


### PR DESCRIPTION
Partly closes open-formulieren/open-forms#5944

Fixes the checkbox input (the actual checkbox square) not being clickable in iOS 18.

The checkbox label is render after the input, placing it higher in the DOM order. To fix any visual issues, negative margin and positive padding were added, ensuring the label is rendered next to the checkbox while the background styling is applied behind the input. In other browsers this isn't a problem, the input is clickable through the padding. In iOS 18 the padding pulls click actions to the label wrapper, prevents you from clicking the input.

By defining the z-index we force the checkbox input in a stacking context, placing it above the padding area. This makes the input clickable for iOS versions 18, 17, 16, and perhaps more versions below these.

As the Formio-renderer is used in multiple versions of the OF SDK, we might need to backport this. The used versions are as follows:
SDK latest = renderer 1.5.x
SDK 3.4.x = renderer 1.1.x
SDK 3.3.x = renderer 0.9.x

For the latest version of the SDK we can simply create a new release, and update the SDK dependency.

For the older versions of the SDK, we need to check if we can upgrade the renderer to 1.5.x, or if we need to create backports of this fix. Alternatively we could add this styling fix to the SDK directly. (As the formio-renderer styling is applied regardless of which renderer is used (or at least, that seems the case in local development), we don't need any additional changes if we decide to backport/fix this from the Formio-renderer side)