### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -201,7 +201,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -426,7 +425,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1946,7 +1944,6 @@
       "integrity": "sha512-O0piBKY36YSJhlFSG8p9VUdPV/SxxS4FYDWVpr/9GJuMaepzwlf4J8I4ov1b+ySQfDTPhc3DtLaxcT1fN0yqCg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3450,7 +3447,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3769,7 +3765,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3781,7 +3776,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3880,7 +3874,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -4391,19 +4384,22 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/accordion-css/-/accordion-css-3.0.1.tgz",
       "integrity": "sha512-BWqGNjsJKzZ468gNbicMNyNoAwEAdN6msViCGURrW/tIsWRqoIcck3CozGuWdS9u7pakasfi6hhHvPbXcz4CoA==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/action-group-css": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/action-group-css/-/action-group-css-3.0.1.tgz",
       "integrity": "sha512-IFOWCIMgcr44MuqotyY7wC3KXOMaxvcn8ZoDtCISK+5uG5NjbSsdI9DyegrWBq8M7fGPLnjDMdWCmIVFM2lgCA==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/action-group-react": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@utrecht/action-group-react/-/action-group-react-1.1.4.tgz",
       "integrity": "sha512-W+0+x2wJ9058wNDYnK1dCfUKCFfNVsDcezm/MmBgmOW/vUnX/095TVzhPboL6vVdHQTESY4uaCjinmvwI/sx6A==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/action-group-css": "3.0.1",
         "clsx": "2.1.1"
@@ -4424,49 +4420,57 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/alert-dialog-css/-/alert-dialog-css-2.0.1.tgz",
       "integrity": "sha512-bFvApN6WdxSeh2lzg8DyhC2G0n3KXLJRQANgCWanIyXo89AqCe0EK39SRhPJl8g54cMMu1VBOFqqsj0XrfJOKQ==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/alternate-lang-nav-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/alternate-lang-nav-css/-/alternate-lang-nav-css-2.0.1.tgz",
       "integrity": "sha512-NpzpeUfZUIq9UIZwHeNGumR56Gw7bzbAE98sAgtQeaIJfGz3veLMAvXfZP+9EtM5srJhlF1hHI+R4fxcqGdOKg==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/article-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/article-css/-/article-css-2.0.1.tgz",
       "integrity": "sha512-FXJ0KVsCobM4Bo2fEapUZksUtokaUQpJV8qYHt19H+lobCiv9D9FTYYy+F+udX3u/TaSLj56gewxK12gQP1a5Q==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/backdrop-css": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/backdrop-css/-/backdrop-css-2.0.2.tgz",
       "integrity": "sha512-b2GoEvwp50AUEgGrLNxOCKo/FTZPg3gCo7wr/6jl6h9x9vPLYhmOZebafe2jxsWxCEWS4dXqfC5M2uQFJ19MJg==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/badge-counter-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/badge-counter-css/-/badge-counter-css-2.0.1.tgz",
       "integrity": "sha512-0wfv6eIvQQRPKf98Mu4veFXT2l57MAd0uEGHqD78tCcoG62ugveXvWbQMyae5drzzEUNWdf/2Mn67qLyKVcK/w==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/badge-list-css": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/badge-list-css/-/badge-list-css-3.0.1.tgz",
       "integrity": "sha512-ujhscNHXxliZ/DZHa6xitpDArF+S32b6baP8erRbAo7SiP90aFw+3zQ7Uj0d5IAMXMCOOiTrRp8q9GWTAMRy+Q==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/blockquote-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/blockquote-css/-/blockquote-css-2.0.1.tgz",
       "integrity": "sha512-uiGEhc77nM8OFEsuAR5viABV2NiRGZi3Mve2wUxtvrctPirLV/kQJWn3/pt2NCKSeuFqSnpVvCzgPe46F8PteQ==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/breadcrumb-nav-css": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@utrecht/breadcrumb-nav-css/-/breadcrumb-nav-css-2.1.0.tgz",
       "integrity": "sha512-BOYqFSnrR5rVzU1mb4eDb4BbpuE9TSEPN5FTlJJduYDvsJr5DLDaxADmFp1p05di7GWV1qTaPBMxw0gEuMAbaQ==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/button-css": {
       "version": "3.1.0",
@@ -4535,6 +4539,7 @@
       "resolved": "https://registry.npmjs.org/@utrecht/calendar-react/-/calendar-react-1.1.2.tgz",
       "integrity": "sha512-UJ+bhZInjp0iahE+wqUgBSkajp5MZ5PRvk4qyrzSy77zCuBJNZNJD+qhq3Ci89LlnMNpBvMVDTCl2wp5Jx7gUA==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/button-react": "3.0.1",
         "@utrecht/calendar-css": "2.0.1",
@@ -4553,6 +4558,7 @@
       "resolved": "https://registry.npmjs.org/@utrecht/button-react/-/button-react-3.0.1.tgz",
       "integrity": "sha512-PlM0+KjOKoGVGsdSTsWASiO8dsYFbHMq8CD8JH3D9UxMRzJR5NCwY9hva9jGSr8KbIc+WImDEatyxtvMwMIxUg==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/button-css": "3.1.0",
         "clsx": "2.1.1"
@@ -4568,6 +4574,7 @@
       "resolved": "https://registry.npmjs.org/@utrecht/card-css/-/card-css-1.0.1.tgz",
       "integrity": "sha512-zklTHHTxmQ++/AYSLk5O7NRxNvd6Mzmch6vBcuts2Nj78UeGB2xvjzPlNnr5/FQV65Dm1QpP8bE71K2SANz7eA==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/img-css": "2.0.1"
       }
@@ -4577,6 +4584,7 @@
       "resolved": "https://registry.npmjs.org/@utrecht/card-react/-/card-react-0.0.4.tgz",
       "integrity": "sha512-+1hsXn6k4ixXmeWZsi1GPRyErlcXzaN0cgLk5L1iQNVWnUBbkvYqbn76jF95MX2Jg4aiv6/zNdC59f10S/+g7Q==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/card-css": "1.0.1",
         "@utrecht/link-react": "1.0.10",
@@ -4593,6 +4601,7 @@
       "resolved": "https://registry.npmjs.org/@utrecht/link-react/-/link-react-1.0.10.tgz",
       "integrity": "sha512-MAD/0bJN6Fxb6tHK5F/2vFD9wmqPw5dC98AgXriq6BnY4g9UPsM5NBgLHt8mMJ5gYF9hZzyxucqQVTetzgKsYQ==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/link-css": "2.0.1",
         "clsx": "2.1.1"
@@ -4638,37 +4647,43 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/code-block-css/-/code-block-css-2.0.1.tgz",
       "integrity": "sha512-isBpsG7lN6qp1LdvBVmwVsTH2NlbzwAitgFzjH6Q60XyKhHB+cjW7irq43AaESKor1m2G1KdhQUZsbhkPjHzMw==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/code-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/code-css/-/code-css-2.0.1.tgz",
       "integrity": "sha512-PEWcAYsBSEo/6GSOFQW/Bt7l7nT6yXn+QJoFJUFWtX6xRHuSu91m3ISbzmhozMQJX7mCl6mUXdHt7EVRUqlFKA==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/color-sample-css": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/color-sample-css/-/color-sample-css-2.0.2.tgz",
       "integrity": "sha512-9Tc9ro0X4zU6oXLrIkj9lNYiYTHYRG02FtREP9Z0XrhqlfuAg2HkPts/GHgKj0ejlrfJOJP22VeMzuMfTJUhOg==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/column-layout-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/column-layout-css/-/column-layout-css-2.0.1.tgz",
       "integrity": "sha512-HqK7QuMyftLSRvV7j+zG8szXbXi73rkWR776DsWQDg/SwebLaasjGuCTOgg7J7YTR0EK2+fj7s61R+utx7CDhg==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/combobox-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/combobox-css/-/combobox-css-2.0.1.tgz",
       "integrity": "sha512-BUpeg4RNO/MezKQLMVdCIGCYlBvq9piKbsLwAROtQtEiGLWJlDqPL39OtCp2vZo1sesDUphVdXaYG9NiOrk8og==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/combobox-react": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/@utrecht/combobox-react/-/combobox-react-0.0.11.tgz",
       "integrity": "sha512-oA6Si8C7wD7sbU5RqoQBdY5tAYpJa6YwhvFMIchJjLdqmV8oGT+ZV8vWWbjtDiPPnZPWcZyO1U08mOd+fqQgDQ==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/combobox-css": "2.0.1",
         "clsx": "2.1.1"
@@ -4684,6 +4699,7 @@
       "resolved": "https://registry.npmjs.org/@utrecht/component-library-react/-/component-library-react-13.1.0.tgz",
       "integrity": "sha512-MarmH3cIyT+6Ckp83b1xYR7JpqNfrjI0n2lt1GQK6cqiy6DTuSODrFEnvDY92fwL4GHEMn4C0qi3g17THUqyew==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/accordion-css": "3.0.1",
         "@utrecht/action-group-react": "1.1.4",
@@ -4811,6 +4827,7 @@
       "resolved": "https://registry.npmjs.org/@utrecht/button-react/-/button-react-3.0.1.tgz",
       "integrity": "sha512-PlM0+KjOKoGVGsdSTsWASiO8dsYFbHMq8CD8JH3D9UxMRzJR5NCwY9hva9jGSr8KbIc+WImDEatyxtvMwMIxUg==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/button-css": "3.1.0",
         "clsx": "2.1.1"
@@ -4825,13 +4842,15 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/checkbox-css/-/checkbox-css-2.0.2.tgz",
       "integrity": "sha512-r4mfnI/so3sgi9cXJrvKtXPsMxA5swloNEvAB3ia9ny8SjbJVRwjNOj/IX6aFnT+eHOFUIitpf59NvDtMot1aA==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/component-library-react/node_modules/@utrecht/checkbox-react": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@utrecht/checkbox-react/-/checkbox-react-1.0.12.tgz",
       "integrity": "sha512-WXtpzmF9jOT9qceD2823z3Pr+b2OTv7vlq5Q5as4pZpkhPOoCKjfUdvICt0dSyOs8I4FPh3JhENuMHqoGt2AcQ==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/checkbox-css": "2.0.2",
         "@utrecht/custom-checkbox-css": "2.0.1",
@@ -4848,6 +4867,7 @@
       "resolved": "https://registry.npmjs.org/@utrecht/fieldset-react/-/fieldset-react-1.0.11.tgz",
       "integrity": "sha512-/8lje8gpfcLu3NEZTdwfQ1szMsfV0o5FbM+aNYHedkMpbljQKtXJeqoV64LrZhBmXpvUmnNQz1I5E+e04XhT+w==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/form-fieldset-css": "2.0.2",
         "clsx": "2.1.1"
@@ -4863,6 +4883,7 @@
       "resolved": "https://registry.npmjs.org/@utrecht/form-field-description-react/-/form-field-description-react-1.0.10.tgz",
       "integrity": "sha512-tuK+ZdjnqxuWPPpi1O6dehzTmp49dTlE6/SlptILZDISIwS1ud1snwDqWjxAc5ytzdkf1wCJVeIFbAZVm1MMOQ==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/form-field-description-css": "2.0.1",
         "clsx": "2.1.1"
@@ -4878,6 +4899,7 @@
       "resolved": "https://registry.npmjs.org/@utrecht/form-field-react/-/form-field-react-1.0.11.tgz",
       "integrity": "sha512-99FZaRXTEaE0TtkeU4/LvwH/YgQfT1ZhN/fM0XqPpvoxEOfPvBkspV4oIDGOKg9dMvrzX8N3F/YhOy1QNOBcLw==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/form-field-css": "2.0.2",
         "clsx": "2.1.1"
@@ -4893,6 +4915,7 @@
       "resolved": "https://registry.npmjs.org/@utrecht/form-label-react/-/form-label-react-1.0.10.tgz",
       "integrity": "sha512-oJhcTpVg38jRYEl2fOxvZAJHfaEyeQRTpQCxTZ6Mcv1dr1dhE259TwM03DtRXa+JTJoulxUG7vxTyclmxQwY3Q==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/form-label-css": "2.0.1",
         "clsx": "2.1.1"
@@ -4908,6 +4931,7 @@
       "resolved": "https://registry.npmjs.org/@utrecht/link-react/-/link-react-1.0.10.tgz",
       "integrity": "sha512-MAD/0bJN6Fxb6tHK5F/2vFD9wmqPw5dC98AgXriq6BnY4g9UPsM5NBgLHt8mMJ5gYF9hZzyxucqQVTetzgKsYQ==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/link-css": "2.0.1",
         "clsx": "2.1.1"
@@ -4923,6 +4947,7 @@
       "resolved": "https://registry.npmjs.org/@utrecht/radio-button-react/-/radio-button-react-1.0.11.tgz",
       "integrity": "sha512-pMNR1Yyj82uSE06m3tzeyAMeL5jm2JDulR/MwsHn1rIpQylz0Lyj5597jvbRjw+CPvvj9cyoUe9DnBzx/6xkew==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/radio-button-css": "2.0.2",
         "clsx": "2.1.1"
@@ -4938,6 +4963,7 @@
       "resolved": "https://registry.npmjs.org/@utrecht/textbox-react/-/textbox-react-1.0.14.tgz",
       "integrity": "sha512-ouhtKqPUYLwgNETITFSehsWPxGwoOjs1oNBgIE1PamONrDhY8HtCdeC1IUo6VBAu1la1tIhz2XYq3VqV0bjEQg==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/textbox-css": "3.1.1",
         "clsx": "2.1.1"
@@ -4952,7 +4978,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/currency-data-css/-/currency-data-css-2.0.1.tgz",
       "integrity": "sha512-RjbY93rP5+LsNAlcA6krrzt/lwjtI+gMALqEsw9srHXJQvF3DcJUxlR/fUfS7H6EdMy26OxRJGJ+XQ4wL6P4hA==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/custom-checkbox-css": {
       "version": "2.0.1",
@@ -4964,13 +4991,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/data-badge-css/-/data-badge-css-2.0.1.tgz",
       "integrity": "sha512-UMisFH+47SvLFKicA+Em9el8ksyfoO2UtNZHODSL6qf+Bb33QQhGHnnBvcuKg1LTtiK1YdjHxVlnk05wCuFSqQ==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/data-badge-react": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@utrecht/data-badge-react/-/data-badge-react-1.0.7.tgz",
       "integrity": "sha512-+RLDmI1tWBIloMA2Qt1bROOfXgssfu5H2mKKO5RWwqkFRtGXsvvUyLYv1TFaLYQCRZFzGjXjwVN97zrbIUaPFg==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/data-badge-css": "2.0.1",
         "clsx": "2.1.1"
@@ -4991,13 +5020,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/data-placeholder-css/-/data-placeholder-css-2.0.1.tgz",
       "integrity": "sha512-eM81866Pcnpdi+6B6AvCffJjfrsrmpNIZpGScrS4qTGJwePtsnd76bT6NB1eP3NFkA/Ptnfvs4UjFAO3KAK4Zg==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/digid-button-css": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@utrecht/digid-button-css/-/digid-button-css-1.4.2.tgz",
       "integrity": "sha512-lE0/KipLVHaxb7YeZC3YPqSiSaDVyCkzSWmxLjs8k5ghzId8WI4vG8P42716gDBh9tsfdX0kRcVFdh5KerSiyw==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/document-css": {
       "version": "2.0.1",
@@ -5009,13 +5040,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/drawer-css/-/drawer-css-2.0.1.tgz",
       "integrity": "sha512-4YysV31TmYGK8mLIF0ZLnUsc7j+02TylXJVZrMDQzisasEUbh8FXhHNbGTyZxlmGaFfjMtblCldp/UnsLkFH2Q==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/emphasis-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/emphasis-css/-/emphasis-css-2.0.1.tgz",
       "integrity": "sha512-lnFb2l7puRIMKCy/4w9Zvg1Ipi6rSaJMyxyG7q30EH6kUpY/R4NYZYgLTkB5gzvPGBddfywvl20c590sYd9dHQ==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/fieldset-react": {
       "version": "1.0.12",
@@ -5044,19 +5077,22 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/figure-css/-/figure-css-2.0.1.tgz",
       "integrity": "sha512-+mAPgdcd+0ZrQZR74h4VdDsxqkfs3e1DYDhgfcu9qAmQfb1MfSz8HkHFkZFtkuQYd854UsHeTTVq3UkwZTM04g==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/focus-ring-css": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@utrecht/focus-ring-css/-/focus-ring-css-3.1.0.tgz",
       "integrity": "sha512-KIymUn473aRCW0eu/ZS4dEMKZF9mPE+npfoEsfKKGBTX51feZ7HiLnB7f4xqrxIfmd2Z3zxYtSxtvMgidSHA6Q==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/form-field-checkbox-react": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@utrecht/form-field-checkbox-react/-/form-field-checkbox-react-1.1.4.tgz",
       "integrity": "sha512-D5wbgcOmyUPIvZwN087k0d60kn25IV+43CgKmn4NssRonfVKFECEXXo3aZ53TfyVtTWRAyDJK9xzWpy/7KCs5Q==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/checkbox-react": "1.0.12",
         "@utrecht/form-field-description-react": "1.0.10",
@@ -5075,13 +5111,15 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/checkbox-css/-/checkbox-css-2.0.2.tgz",
       "integrity": "sha512-r4mfnI/so3sgi9cXJrvKtXPsMxA5swloNEvAB3ia9ny8SjbJVRwjNOj/IX6aFnT+eHOFUIitpf59NvDtMot1aA==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/form-field-checkbox-react/node_modules/@utrecht/checkbox-react": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@utrecht/checkbox-react/-/checkbox-react-1.0.12.tgz",
       "integrity": "sha512-WXtpzmF9jOT9qceD2823z3Pr+b2OTv7vlq5Q5as4pZpkhPOoCKjfUdvICt0dSyOs8I4FPh3JhENuMHqoGt2AcQ==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/checkbox-css": "2.0.2",
         "@utrecht/custom-checkbox-css": "2.0.1",
@@ -5098,6 +5136,7 @@
       "resolved": "https://registry.npmjs.org/@utrecht/form-field-description-react/-/form-field-description-react-1.0.10.tgz",
       "integrity": "sha512-tuK+ZdjnqxuWPPpi1O6dehzTmp49dTlE6/SlptILZDISIwS1ud1snwDqWjxAc5ytzdkf1wCJVeIFbAZVm1MMOQ==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/form-field-description-css": "2.0.1",
         "clsx": "2.1.1"
@@ -5113,6 +5152,7 @@
       "resolved": "https://registry.npmjs.org/@utrecht/form-field-react/-/form-field-react-1.0.11.tgz",
       "integrity": "sha512-99FZaRXTEaE0TtkeU4/LvwH/YgQfT1ZhN/fM0XqPpvoxEOfPvBkspV4oIDGOKg9dMvrzX8N3F/YhOy1QNOBcLw==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/form-field-css": "2.0.2",
         "clsx": "2.1.1"
@@ -5128,6 +5168,7 @@
       "resolved": "https://registry.npmjs.org/@utrecht/form-label-react/-/form-label-react-1.0.10.tgz",
       "integrity": "sha512-oJhcTpVg38jRYEl2fOxvZAJHfaEyeQRTpQCxTZ6Mcv1dr1dhE259TwM03DtRXa+JTJoulxUG7vxTyclmxQwY3Q==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/form-label-css": "2.0.1",
         "clsx": "2.1.1"
@@ -5177,13 +5218,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/form-field-error-message-css/-/form-field-error-message-css-2.0.1.tgz",
       "integrity": "sha512-4Oe5aIgMNkKXHcCZ86z+/ClSbaDxZ4atxdqgFPU1mi1L7P07QK2yatUGvjOlV1h4dwXMyl2zcNkxCn62wPhJvw==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/form-field-error-message-react": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@utrecht/form-field-error-message-react/-/form-field-error-message-react-1.0.10.tgz",
       "integrity": "sha512-RJxKw9J1qcoyZ7uGArDQirKcoBTWXoDULXe2W8OzA3ug2hKN4MM1S06HoxSDLIjqvLdjklrPFe3ffBkuIytg9g==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/form-field-error-message-css": "2.0.1",
         "clsx": "2.1.1"
@@ -5256,13 +5299,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/form-toggle-css/-/form-toggle-css-2.0.1.tgz",
       "integrity": "sha512-VHa8KXKfAo3gr53ZCxYute0GPACDTrM9fdSmtakmS9Iu9s6niJgkkZmhFfNY+X5N75rEQiI+aTmFyA5TM/xh+g==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/heading-1-css": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/heading-1-css/-/heading-1-css-2.0.2.tgz",
       "integrity": "sha512-QKTepHh+Ow5ao37gJxHlMTfH11UQ1Cr0aVao4/StIWO7WNwxba5VWVgYyLpcrToDSEX6FFgWKalWPQ96hVIOjQ==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/heading-2-css": {
       "version": "2.0.2",
@@ -5274,31 +5319,36 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/heading-3-css/-/heading-3-css-2.0.2.tgz",
       "integrity": "sha512-jl5QLdtrcwaCN/WnObpkPisHwyyuqurgihp0JP6dL0wZz5OtpWAsTkMCDJPyEwXHZ9ozpdWl26xiTE/ukno0Ng==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/heading-4-css": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/heading-4-css/-/heading-4-css-2.0.2.tgz",
       "integrity": "sha512-P5RYGfDEdYB6vMqBUd7Wlvz2sP5cESGVjYiWCSdAtVusvzCnTHb5JkiLaZcobSpOMFJXcOFZGGRLmnbEwTtr0Q==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/heading-5-css": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/heading-5-css/-/heading-5-css-2.0.2.tgz",
       "integrity": "sha512-9frKz5wIY7PzInga6gyXRCRRPVBSnuuhLM5w5bo+3fCjOVtuqwTBZifNV1yqJrarxnJhB1BYsxJFvPTFqtz/dQ==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/heading-6-css": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/heading-6-css/-/heading-6-css-2.0.2.tgz",
       "integrity": "sha512-XIEta/MnPOz8ec2lxeA7Ix+NjFNLAv3FSCZ9XnTPMnDGeNotk/0nqiTiEzXrFnP/Z2AD/yIcWyureXUpxorZ1g==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/heading-group-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/heading-group-css/-/heading-group-css-2.0.1.tgz",
       "integrity": "sha512-MgeMBWVcmLXG4bZRtneSdBvf0cq1PR9mBHSS5ldPKCfJZ0Xdl2bOH9CMah6XABUL5reyvw55JbE0zvJoHyKvmA==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/html-content-css": {
       "version": "2.1.0",
@@ -5310,7 +5360,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/iban-data-css/-/iban-data-css-2.0.1.tgz",
       "integrity": "sha512-K7kcT1w9JRPLQWWjmj7O0UNDBcTMOv1gAzDWhE7hQwxcbwDrL/e4DAcrrmR7bicH9soParrDTr+wEq4OxNJl8Q==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/icon-css": {
       "version": "3.0.1",
@@ -5322,19 +5373,22 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/img-css/-/img-css-2.0.1.tgz",
       "integrity": "sha512-G5D1Nc7SlQeUgKic14s7VdsMcXxSquyS0INNmq79ejf73l6GNXY7E+Gag3JwyOopHUAKqW1u5fKZG00bySPabA==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/index-char-nav-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/index-char-nav-css/-/index-char-nav-css-2.0.1.tgz",
       "integrity": "sha512-/sCn0vamJZaFDYx0hyFgKSVJgAndGtMsDRs287vR5fkJzGjeNoFH+cigYukIpjj/55bvFVjuLdFWT9toGiIkVA==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/link-button-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/link-button-css/-/link-button-css-2.0.1.tgz",
       "integrity": "sha512-7HxgKyp7IkV0PAZb90ASvr9Iz+BPMw4yqpiN3IiD5HdPzTwQY8CjW7k4/hFZXrh/MMwnRUwcrDLJsbCLSfyKrw==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/link-css": {
       "version": "2.0.1",
@@ -5346,7 +5400,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/link-list-css/-/link-list-css-3.0.1.tgz",
       "integrity": "sha512-/+pNmHFGadl/zVy0I3G6TVNWB3EuqRLvjsoBL7ue9+wJeye4LqDcweYgdFKm7wFcN4Tci479j21fZ63IK4KlXA==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/link-react": {
       "version": "1.0.11",
@@ -5375,25 +5430,29 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/link-social-css/-/link-social-css-2.0.1.tgz",
       "integrity": "sha512-njEvSkMm9Nvp4Bzxxly/WY8qMC3KFgWFT2K/z72JaTmbVUuqfYmRhw7HgZEPhRCKdFZ5BhI4T83Cbw0uHxLvgg==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/list-social-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/list-social-css/-/list-social-css-2.0.1.tgz",
       "integrity": "sha512-VQiJRl00582GpBfoDV3UkURUUuo3tvdL0K9k8IXCA6tOuLIntf3n8zMB+fV2UciEPkDt0J/1qlXiyhtYz6hs4g==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/listbox-css": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@utrecht/listbox-css/-/listbox-css-2.1.1.tgz",
       "integrity": "sha512-GF1/Ed5Cx9wf9LffMgg5gS2v9WoR+tQbw9IwRfkVhwz4zjQ1TuoT3D7MdcxsEffFj4oJB80ZQq0LTUlcm0JK3Q==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/listbox-react": {
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/@utrecht/listbox-react/-/listbox-react-1.0.15.tgz",
       "integrity": "sha512-PgU4RFOOEHyunke2ghPcgVqmev7awZEpX9lJMp0l4yC7jkvNZHibhute9Wddbtl/pYfV1a2cgOPrmzNEzMhM9Q==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/listbox-css": "2.1.1",
         "clsx": "2.1.1"
@@ -5408,73 +5467,85 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@utrecht/logo-button-css/-/logo-button-css-1.4.2.tgz",
       "integrity": "sha512-urW6k/UWoHYdaLbr/a3qvIhMzIxCOfZYyWkqg3qmBPyxe42hWACXmjy63lbN2WfRZiV7YZKAtGRyDSQ5t5xM5w==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/logo-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/logo-css/-/logo-css-2.0.1.tgz",
       "integrity": "sha512-G2WyPM1Y1UnuQTodTcQ5wXGKm7gz4Wnre6O211ra4CAxhRfIXSxTUiW9waVHrkBOz+rxDy0S57gsBabAOiLGxQ==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/logo-image-css": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@utrecht/logo-image-css/-/logo-image-css-1.4.2.tgz",
       "integrity": "sha512-TV2Svy/dkyYF6Xj422JGwueMe6CcyWZ7+RZAXNgG575nrXYxEVy5EPjfeHPQ7LmCw0QZDlA7vRLK09zbL6LLyQ==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/map-control-button-css": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/map-control-button-css/-/map-control-button-css-3.0.1.tgz",
       "integrity": "sha512-Y5xC2BjUnMJ6kx2X3Ebf5BTSvhPQiOPt5fGBakLFeugNsPP7+WaFv7FKtyv4FmibxwnhXPTMko6TzcypiE7zqQ==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/map-marker-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/map-marker-css/-/map-marker-css-2.0.1.tgz",
       "integrity": "sha512-/Qlscd5ixjeDB4ITNuvaNHyUyn/SbDuxALqOomFLZ4Q1odG1V05vC5XvlR4QsagHC5U5/CDJXKtAQ1mm3nNE0g==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/mark-css": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/mark-css/-/mark-css-2.0.2.tgz",
       "integrity": "sha512-kNIazVB1e1yGEKiY6yoa20Nte7rqpuyQsoqYnudJNz5i/O7XA2MElTi1oKLLtbYeIyIetXKznDqbxRy1OLSKaw==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/multiline-data-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/multiline-data-css/-/multiline-data-css-2.0.1.tgz",
       "integrity": "sha512-4pkVG4Loz/bS697zW2nFemQd91JlRMF3d1ss1WRbWQyXPEhY19R4GvFPhl+Tf7Oq+F2eArV1EYR+nkV9SdiCCQ==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/nav-bar-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/nav-bar-css/-/nav-bar-css-2.0.1.tgz",
       "integrity": "sha512-CKyHi8pe4lk1Dg2IxW8TjbFCkMflEsUHNcrKjzokjygaJS4Pls+LP0dGRt7f7q55JGXb1gjsGedEmXtLNIDRDA==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/nav-list-css": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@utrecht/nav-list-css/-/nav-list-css-1.3.2.tgz",
       "integrity": "sha512-1VGVeIuLgz4N9aJ0DpTHbwRwxeOQSylIdeJ3Gm8sbL2NVIx4N05heEqi3lZKMulgv35ptCROdH/LBnn0Jd41Mw==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/number-badge-css": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/number-badge-css/-/number-badge-css-3.0.1.tgz",
       "integrity": "sha512-t1HwU+bRlerdFicFZa4w5xyZh00ihITUb2kxU11e9Vxb2D32VU1jBOMW8qtKpuiya5mPZJjGF0uc6ZyGPAdXTw==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/number-data-css": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/number-data-css/-/number-data-css-2.0.2.tgz",
       "integrity": "sha512-OOTpNklOn6px7CMOUrAVrn7N2D7VTQYsL8ygFveSJxO3Aa+9VfVh+xCOgsofuAX5F7lNerydwew3fMyude0h9g==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/open-forms-container-css": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@utrecht/open-forms-container-css/-/open-forms-container-css-2.0.4.tgz",
       "integrity": "sha512-G4LD3Yc8IBwaZpLbJ3tCKn0iCYoiwRRHvEjcUWFXkVQWtEnnBoAbmeUTevSfUfHMn8b0UFTjYpw2ovfLF1qRzA==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/focus-ring-css": "3.1.0",
         "@utrecht/textbox-css": "3.1.1"
@@ -5485,6 +5556,7 @@
       "resolved": "https://registry.npmjs.org/@utrecht/open-forms-container-react/-/open-forms-container-react-1.0.8.tgz",
       "integrity": "sha512-ySiAx0REf8SXXCT8mpJcGlENksgPL7z/FOjhNm0fNqcBnc8CJFEOf5lwHMyaQY9+lx7jbOc9O76S709es/9SjA==",
       "license": "EUPL-1.2",
+      "peer": true,
       "dependencies": {
         "@utrecht/open-forms-container-css": "2.0.4",
         "clsx": "2.1.1"
@@ -5505,31 +5577,36 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/page-content-css/-/page-content-css-2.0.1.tgz",
       "integrity": "sha512-Hgx63BEUbaGJyBQXpa97EN8ng0M9LTX3ddu9IQM+ar/rA2OGIM5oiGbwXUYhLwQp/HnhkFm/gpPGGTtQjpXC6w==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/page-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/page-css/-/page-css-2.0.1.tgz",
       "integrity": "sha512-5c0wLiFvnfpTn8VfjoRHmND0DSw/CYD8ydkgdZNCFkSaXOqVrhcAN3I6jTMSR+Eg9mOu1T9bswRcxIKa8NUJUA==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/page-footer-css": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/page-footer-css/-/page-footer-css-3.0.2.tgz",
       "integrity": "sha512-HjO1l3fI+RUE0d3QiQHbN6z6maXvoerXiU7vpA+Qidkmlcvrm7r565cOLOTJKl191YaZb2l3b0FSoB8kGK7Xwg==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/page-header-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/page-header-css/-/page-header-css-2.0.1.tgz",
       "integrity": "sha512-HxONNJxBNwqEY/qDkx3U0wAVvirc/1l04i9L4dPscjf+Le6UWkJb4pfxXVO8b8yIT+wyj2YY0k8aeBUEIJPKjA==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/pagination-css": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@utrecht/pagination-css/-/pagination-css-2.0.3.tgz",
       "integrity": "sha512-LXXWZXEgiOacCHljs9jm9Nm2MQW7dmNtq5Ck4PENOA62oT/HVCXbiviWeT+dYLsv8Nwv+JCFYWm4CA1UGY7MOw==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/paragraph-css": {
       "version": "3.0.1",
@@ -5541,13 +5618,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/pre-heading-css/-/pre-heading-css-2.0.1.tgz",
       "integrity": "sha512-fIbGQv17jrNLgVosvcAMZOn4QR+9v3q0OgozdZ4htLkvRb92oyeHck/uhaOXtJnqWkDeWR9pf1CCwdIn9zxRCg==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/preserve-data-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/preserve-data-css/-/preserve-data-css-2.0.1.tgz",
       "integrity": "sha512-GDEXsGQhHTNShHVdrQlToKmglB73cXTrr3h2Zu40rF7wo/BV75qWVviH3CEh0gSOy8SLHyMgbwCBk+A0Nnp7AQ==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/radio-button-css": {
       "version": "2.0.2",
@@ -5582,13 +5661,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@utrecht/rich-text-css/-/rich-text-css-2.1.0.tgz",
       "integrity": "sha512-JYr/I/wZKufKe6iji6BxQYxtNnNuhyEylOrjFH+Ju5Cz5uqD4KU5zmsjNHhYX7bMIsdUQcje4VnXNtarM4xBkw==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/search-bar-css": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/search-bar-css/-/search-bar-css-3.0.2.tgz",
       "integrity": "sha512-R7hORuwr2u/zVLybHxO72ZpPx0MtTTqoTBBrpLsgLNJGUsbS6s61e83RXGmE+Dr8U9Mokj1K2DTjnNxsYtSxzA==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/select-css": {
       "version": "2.0.2",
@@ -5600,25 +5681,29 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/separator-css/-/separator-css-2.0.1.tgz",
       "integrity": "sha512-TpD/3w8N14XJD3hRKqpgftLFlmNveheNN9KUjBD3MEJF96i9e7S/4+YIasWicCHxrsQpicc28ERJLlGCRow+UA==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/skip-link-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/skip-link-css/-/skip-link-css-2.0.1.tgz",
       "integrity": "sha512-cH2UHLrcSKJHWid1i+VRzsrZMxLAHjmXiU332H5PJDLf5ImjjF0YVaw41+/d0yfWVH5UIEJj+el7naFzyA9/1w==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/spotlight-section-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/spotlight-section-css/-/spotlight-section-css-2.0.1.tgz",
       "integrity": "sha512-BzymCAj6Im0OAzpHs3iSqX+5lNIVD9EbElC9RCeFASTlp5Yc9iO2hj9CCeQD6yPuVuZBD84vND6p4JeMgeLPJg==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/status-badge-css": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@utrecht/status-badge-css/-/status-badge-css-1.0.0.tgz",
       "integrity": "sha512-rkbK0l+DdXMApss6WJWKPzRk0/5k3q0Q+UB0Uzc0YdhZJG7iUS/RzmygDDcv346HfI5Ki8nZT3HG7Wjw2rIWMQ==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/subscript-css": {
       "version": "2.0.1",
@@ -5636,7 +5721,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/surface-css/-/surface-css-2.0.1.tgz",
       "integrity": "sha512-CVFH5D41ePrS7Lqw7Tlxl4/Wy06yiP7pEjp+ZJkuPuaXLrmHO+S0L78t01xNzoVm8ASUyFjz3VTT3NdvZFDXyw==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/table-css": {
       "version": "2.0.3",
@@ -5648,7 +5734,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/table-of-contents-css/-/table-of-contents-css-1.0.2.tgz",
       "integrity": "sha512-xMZM/MuwK+c0bLLrqdWq5HfJy2OmLM9C2y8seLOjbxO9qVoYKNbFKUg/WsuR0J0VCzLRQz/w7UzAMj0MSqckrA==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/textarea-css": {
       "version": "3.0.2",
@@ -5689,13 +5776,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/top-task-link-css/-/top-task-link-css-2.0.1.tgz",
       "integrity": "sha512-SYO6xr4Q1ipaw1xXT1UZMCnjm0MwtKzdgE9NX7ahfBv4wWKiUnLF8yoykYgFTHQIGhIiiV6VW6L6gazFLx3f+w==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/top-task-nav-css": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@utrecht/top-task-nav-css/-/top-task-nav-css-1.3.2.tgz",
       "integrity": "sha512-jdSjHfNcnyokuwwHB2cEYMRRMckLP90hdMiM8omUl2aUf1zL0gqBpzca2uKJPgrzv+PaL1R5XuJGcP6NC8vJkQ==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/unordered-list-css": {
       "version": "2.0.1",
@@ -5713,7 +5802,8 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@utrecht/vega-visualization-css/-/vega-visualization-css-1.4.2.tgz",
       "integrity": "sha512-JTTx1DsKIeYZz95+H34HGfocKjDpbVOsFdPK1f/b3U3C5ivdC75fTkzU1+tVp6ijPwKnWPNr6eiIXTY9tHj5Kg==",
-      "license": "EUPL-1.2"
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -5742,7 +5832,6 @@
       "integrity": "sha512-CS9KjO2vijuBlbwz0JIgC0YuoI1BuqWI5ziD3Nll6jkpNYtWdjPMVgGynQ9vZovjsECeUqEeNjWrypP414d0CQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@blazediff/core": "1.9.1",
         "@vitest/mocker": "4.1.3",
@@ -5766,7 +5855,6 @@
       "integrity": "sha512-D3Q+YozvSpiFaLPgd6/OMbyqEIZeucSe6AHJJ7VnNJKQhIyBE60TlBZlxzwM8bvjzQE9ZnYWQCPeCw5pnhbiNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.1.3",
         "@vitest/mocker": "4.1.3",
@@ -6032,7 +6120,6 @@
       "integrity": "sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.3",
         "pathe": "^2.0.3"
@@ -6317,7 +6404,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6809,7 +6895,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7775,7 +7860,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -7840,7 +7924,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7901,7 +7984,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7965,7 +8047,6 @@
       "integrity": "sha512-1iM2zeBvrYmUNTj2vSC/90JTHDth+dfOfiNKkxApWRsTJYNrc8rOdxxIf5vazX+BiAXTeOT0UvWpGI/7qIWQOw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.1",
         "eslint-import-context": "^0.1.8",
@@ -8029,7 +8110,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8110,7 +8190,6 @@
       "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "aria-query": "^5.3.2",
         "array-includes": "^3.1.8",
@@ -8151,7 +8230,6 @@
       "integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prettier-linter-helpers": "^1.0.1",
         "synckit": "^0.11.12"
@@ -8183,7 +8261,6 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -8217,7 +8294,6 @@
       "integrity": "sha512-St9EKZzOAQF704nt2oJvAKZHjhrpg25ClQoaAlHmPZuajFldVLqRDW4VBNAS01NzeiQF0m0qhG1ZA807K6aVaQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@babel/parser": "^7.24.4",
@@ -8261,7 +8337,6 @@
       "integrity": "sha512-rEFkfU3ypF44GpB4tiJ9EFDItueoGvGi3+weLHZax2ON2MB7VIDsxdSUGvIU5tMURg+oWYlpzCyLm4TpDq2deA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/utils": "^8.48.0"
       },
@@ -8676,7 +8751,6 @@
         }
       ],
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/hoist-non-react-statics": "^3.3.1",
         "deepmerge": "^2.1.1",
@@ -10057,16 +10131,14 @@
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/leaflet-draw": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-1.0.4.tgz",
       "integrity": "sha512-rsQ6saQO5ST5Aj6XRFylr5zvarWgzWnrg46zQ1MEOEIHsppdC/8hnN8qMoFvACsPvTioAuysya/TVtog15tyAQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/leaflet-geosearch": {
       "version": "4.2.2",
@@ -10209,7 +10281,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
       "integrity": "sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -11222,6 +11295,7 @@
       "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright-core": "1.58.2"
       },
@@ -11241,6 +11315,7 @@
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -11259,6 +11334,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -11328,7 +11404,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11416,7 +11491,6 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -11455,7 +11529,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -11513,7 +11586,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -11551,7 +11623,6 @@
       "integrity": "sha512-VE/0Wi/lHJlBC7APQpCzLUdIt3GB5B0GZrRW8Q+ACbkHI4j+Wwgg9J1TniN6zmLHmPH5gxXcMy+fkSPfw5p1WQ==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "2.3.6",
         "@formatjs/icu-messageformat-parser": "2.11.4",
@@ -11584,7 +11655,6 @@
       "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
       "dev": true,
       "license": "Hippocratic-2.1",
-      "peer": true,
       "dependencies": {
         "@react-leaflet/core": "^2.1.0"
       },
@@ -11927,7 +11997,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -12061,7 +12130,6 @@
       "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -12475,7 +12543,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -12900,7 +12967,6 @@
       "integrity": "sha512-uBSZu/GZa9aEIW3QMGvdQPMZWhGxSe4dyRWU8B3/Vd47Gy/XLC7tsBxRr13txmmPOEDHZR94uLuq0H50fvuqBw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.1",
@@ -13490,8 +13556,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -13600,7 +13665,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13615,7 +13679,6 @@
       "integrity": "sha512-c7toRLrotJ9oixgdW7liukZpsnq5CZ7PuKztubGYlNppuTqhIoWfhgHo/7EU0v06gS2l/x0i2NEFK1qMIf0rIg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.56.0",
         "@typescript-eslint/parser": "8.56.0",
@@ -13693,7 +13756,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -13812,7 +13874,6 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -14023,7 +14084,6 @@
       "integrity": "sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.3",
         "@vitest/mocker": "4.1.3",
@@ -14538,7 +14598,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
This is the result of running `npm i` locally. When I tried this yesterday for the release, CI was complaining about `fsevents` not being installed, see [action](https://github.com/open-formulieren/formio-renderer/actions/runs/24512615185/job/71803803451). So I manually updated just the version numbers to 1.5.2 in `package-lock.json` and released that.

But when trying to update the renderer in the SDK, I'm getting dependency conflicts, and I'm not entirely sure yet if they are caused by this `package-lock.json` file not being updated properly. EDIT: doesn't seem to be the case, there is a conflict with `vega` being on version 6.2.0, while vega is defined as "^5.25.0" in @utrecht/component-library-react@13.1.0

CI seems to accept it now, though :thinking: 