### PR TITLE
Support @utrecht/component-library-react 14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -141,7 +141,7 @@
         "@utrecht/button-react": "^3.0.2",
         "@utrecht/calendar-react": "^1.1.2",
         "@utrecht/checkbox-react": "^1.0.13",
-        "@utrecht/component-library-react": "^13.1.0",
+        "@utrecht/component-library-react": "^14.0.0 || ^13.1.0",
         "@utrecht/fieldset-react": "^1.0.12",
         "@utrecht/form-field-description-react": "^1.0.11",
         "@utrecht/form-field-react": "^1.0.12",
@@ -4381,27 +4381,27 @@
       ]
     },
     "node_modules/@utrecht/accordion-css": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/accordion-css/-/accordion-css-3.0.1.tgz",
-      "integrity": "sha512-BWqGNjsJKzZ468gNbicMNyNoAwEAdN6msViCGURrW/tIsWRqoIcck3CozGuWdS9u7pakasfi6hhHvPbXcz4CoA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/accordion-css/-/accordion-css-4.0.0.tgz",
+      "integrity": "sha512-yhSykfRnQRX7E7DBpH4p2Av3cSNmuku4iCWHCl7fTSvWoD9hyGDopTcQxviekQxEk2OKs6EkOIAcb74Pon08Zw==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/action-group-css": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/action-group-css/-/action-group-css-3.0.1.tgz",
-      "integrity": "sha512-IFOWCIMgcr44MuqotyY7wC3KXOMaxvcn8ZoDtCISK+5uG5NjbSsdI9DyegrWBq8M7fGPLnjDMdWCmIVFM2lgCA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/action-group-css/-/action-group-css-4.0.0.tgz",
+      "integrity": "sha512-Motxn2R/r4q19EpnRHWxSdKrmA5AF0T3sg0tCp3r0VJJ5cTr0aRvzEQC1eLgk7Hr59e6u8wxpKU4mMkBeCZ1Tw==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/action-group-react": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@utrecht/action-group-react/-/action-group-react-1.1.4.tgz",
-      "integrity": "sha512-W+0+x2wJ9058wNDYnK1dCfUKCFfNVsDcezm/MmBgmOW/vUnX/095TVzhPboL6vVdHQTESY4uaCjinmvwI/sx6A==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@utrecht/action-group-react/-/action-group-react-1.1.5.tgz",
+      "integrity": "sha512-tPrNwhtGVEiUHtcqnHm3Uqz7ECMduGTedERzR8G9YDKIeMqCYp5vyx2L/vvMdbNGzhmPTBuIe7i+GxWelj0s0g==",
       "license": "EUPL-1.2",
       "peer": true,
       "dependencies": {
-        "@utrecht/action-group-css": "3.0.1",
+        "@utrecht/action-group-css": "4.0.0",
         "clsx": "2.1.1"
       },
       "peerDependencies": {
@@ -4414,61 +4414,62 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/alert-css/-/alert-css-3.0.1.tgz",
       "integrity": "sha512-0phAO794XRQcljQz2RcxdnXMvP5JmlRx8SeEq6T0R5oiKTUEWryxzfgfqu1wJ/VGxgKv+JVVGsSYS04HlKirig==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/alert-dialog-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/alert-dialog-css/-/alert-dialog-css-2.0.1.tgz",
-      "integrity": "sha512-bFvApN6WdxSeh2lzg8DyhC2G0n3KXLJRQANgCWanIyXo89AqCe0EK39SRhPJl8g54cMMu1VBOFqqsj0XrfJOKQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/alert-dialog-css/-/alert-dialog-css-3.0.0.tgz",
+      "integrity": "sha512-XzyL9dtNaz1Gk2+GQcKma5rxdo6lr4ZNxl/Hv+vKQxe+9l73cm33yW83eUmHm5Dr2Yggru6TRD6TtnPnrLTcow==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/alternate-lang-nav-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/alternate-lang-nav-css/-/alternate-lang-nav-css-2.0.1.tgz",
-      "integrity": "sha512-NpzpeUfZUIq9UIZwHeNGumR56Gw7bzbAE98sAgtQeaIJfGz3veLMAvXfZP+9EtM5srJhlF1hHI+R4fxcqGdOKg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/alternate-lang-nav-css/-/alternate-lang-nav-css-3.0.0.tgz",
+      "integrity": "sha512-c7QFqy9IJDI6QbvyTRRtxgb6DO8To5skMKwBZpImBCkdtDjawvpUAdvrLj/WZ5q0xjJtkLNnLLkV6OwJ6fLJ1A==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/article-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/article-css/-/article-css-2.0.1.tgz",
-      "integrity": "sha512-FXJ0KVsCobM4Bo2fEapUZksUtokaUQpJV8qYHt19H+lobCiv9D9FTYYy+F+udX3u/TaSLj56gewxK12gQP1a5Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/article-css/-/article-css-3.0.0.tgz",
+      "integrity": "sha512-Xb/+cnVliAhd1NTXeN0IM/lLKvJnUKKatwevYdwfinyRIMpB0HXmMFwNYC3eCmWT3ASVXhnIiMGtBBT8tNLnIA==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/backdrop-css": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@utrecht/backdrop-css/-/backdrop-css-2.0.2.tgz",
-      "integrity": "sha512-b2GoEvwp50AUEgGrLNxOCKo/FTZPg3gCo7wr/6jl6h9x9vPLYhmOZebafe2jxsWxCEWS4dXqfC5M2uQFJ19MJg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/backdrop-css/-/backdrop-css-3.0.0.tgz",
+      "integrity": "sha512-tINTxaFFjLVv2dDjsoMdLRedB1/s0cBxgkQbKpjHQ8rvUPL79yMjY1SOupRqdRz8nvgmP26IAk2T1MYgMcq8yw==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/badge-counter-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/badge-counter-css/-/badge-counter-css-2.0.1.tgz",
-      "integrity": "sha512-0wfv6eIvQQRPKf98Mu4veFXT2l57MAd0uEGHqD78tCcoG62ugveXvWbQMyae5drzzEUNWdf/2Mn67qLyKVcK/w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/badge-counter-css/-/badge-counter-css-3.0.0.tgz",
+      "integrity": "sha512-knit9ewZtsu9w8L7U/x52CCLQ3zadxY2N3iemthvlfP3PIcXhEO9fQEP/nimJM7hRlW5x4v+bsgr45O9AHBIRQ==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/badge-list-css": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/badge-list-css/-/badge-list-css-3.0.1.tgz",
-      "integrity": "sha512-ujhscNHXxliZ/DZHa6xitpDArF+S32b6baP8erRbAo7SiP90aFw+3zQ7Uj0d5IAMXMCOOiTrRp8q9GWTAMRy+Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/badge-list-css/-/badge-list-css-4.0.0.tgz",
+      "integrity": "sha512-NdPuXWV71i/cG5obVgtLTGYSuhG+klfd2eNagAXArpyWzKsUCBIiaGsd4mOdJgWd3sgQrVp2trrxfMRL6pBEBg==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/blockquote-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/blockquote-css/-/blockquote-css-2.0.1.tgz",
-      "integrity": "sha512-uiGEhc77nM8OFEsuAR5viABV2NiRGZi3Mve2wUxtvrctPirLV/kQJWn3/pt2NCKSeuFqSnpVvCzgPe46F8PteQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/blockquote-css/-/blockquote-css-3.0.0.tgz",
+      "integrity": "sha512-JPu+ibAe5T2Zr4zzNMFMDgQfquWBR7kqNukT5iqKICySz6At040bwD1y5P0u07mmlERkH644Gsgm3R6vTRB/JA==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/breadcrumb-nav-css": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@utrecht/breadcrumb-nav-css/-/breadcrumb-nav-css-2.1.0.tgz",
-      "integrity": "sha512-BOYqFSnrR5rVzU1mb4eDb4BbpuE9TSEPN5FTlJJduYDvsJr5DLDaxADmFp1p05di7GWV1qTaPBMxw0gEuMAbaQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/breadcrumb-nav-css/-/breadcrumb-nav-css-3.0.0.tgz",
+      "integrity": "sha512-nKmS1Web4k2BYXPhptGl/ZRqYVKSVdsz4xoFRSZGkpMuy6scAWOcLt+JrDLxAZ918fBnvNAJh5ry4crZBqje5A==",
       "license": "EUPL-1.2",
       "peer": true
     },
@@ -4476,21 +4477,23 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@utrecht/button-css/-/button-css-3.1.0.tgz",
       "integrity": "sha512-4iUf9AG12XR+LkZ8679RJwFY+5RMtoJUuj1iYUohc7BEE2hS28hxQuycZ5g28QQST2M6DGBSjyi5QiG3skAVVw==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/button-group-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/button-group-css/-/button-group-css-2.0.1.tgz",
       "integrity": "sha512-Zby6G9b1KX6aKECBobzVeVuNcvsknpwUwCVZXN7gzxLzNpJXwPC92XYia0mDIhxUcq8rKCQF+ABzZtxeZKqx9A==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/button-group-react": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@utrecht/button-group-react/-/button-group-react-1.1.3.tgz",
-      "integrity": "sha512-eDVLaDEgUlkNIzTa4jSQt9AHNoo+GHah7vv8HywMAqRMwYaAFUkTF71XiqLkARIBQMgp6+SxqgyR+kLFxXSGrQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@utrecht/button-group-react/-/button-group-react-1.1.4.tgz",
+      "integrity": "sha512-IWQ0Wd4Qp7hNG8W6hVcsSW6riVGQN+j6mDZ5FfxUauippyrADd1Zoh0n2KIkfvvqDGLScOIfgHFAcv9YzJa3cg==",
       "license": "EUPL-1.2",
       "dependencies": {
-        "@utrecht/button-group-css": "2.0.1",
+        "@utrecht/button-group-css": "3.0.0",
         "clsx": "2.1.1"
       },
       "peerDependencies": {
@@ -4499,17 +4502,23 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@utrecht/button-group-react/node_modules/@utrecht/button-group-css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/button-group-css/-/button-group-css-3.0.0.tgz",
+      "integrity": "sha512-41r4BAzD79iUf3Djx5vL2wx+PF046Cjr7876LKECmHtS5Q9tz6/Mk7EPgaVCv7BfgmffxtFjMESj9ffleZ7MVw==",
+      "license": "EUPL-1.2"
+    },
     "node_modules/@utrecht/button-link-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/button-link-css/-/button-link-css-2.0.1.tgz",
       "integrity": "sha512-XHVWxMpBRnvuM6x5ak0wdMqC8ueUFCnLBqPiVr/Dsppa/wDC9ZlLBIGbFfPM22x88xYUVcSIAZcrPc1HjBB1/A==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/button-react": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/button-react/-/button-react-3.0.2.tgz",
       "integrity": "sha512-4DBIx72ILtkG15/sFpwqV42+78sJ3SKmQpZXM/7PYfTCo3Y2xYI0Lu1NGTJzN2xp/jlGYwLP//Yoz97msGUZFQ==",
-      "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
         "@utrecht/button-css": "4.0.0",
@@ -4525,24 +4534,24 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@utrecht/button-css/-/button-css-4.0.0.tgz",
       "integrity": "sha512-yDydgsoASatkX3uFtg9032Vnw0JHHmA1e1uEfLixElYsIsVF0pnHQj/zw1bzJAdhYfgFrzql1OV4CmNMfSoiQA==",
-      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/calendar-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/calendar-css/-/calendar-css-2.0.1.tgz",
       "integrity": "sha512-ilczc5hcha8cYFhH28pyrY21DCOl3gEyeWJNiDkdDgFk4esK9MhJUT7D0d334g6uSARzasI61ZEM6A8Czndfqw==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/calendar-react": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@utrecht/calendar-react/-/calendar-react-1.1.2.tgz",
-      "integrity": "sha512-UJ+bhZInjp0iahE+wqUgBSkajp5MZ5PRvk4qyrzSy77zCuBJNZNJD+qhq3Ci89LlnMNpBvMVDTCl2wp5Jx7gUA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@utrecht/calendar-react/-/calendar-react-1.1.3.tgz",
+      "integrity": "sha512-lq2Nd5254ALm0zN+j6RBjLDX9I9c8BkNI6Ngj1XJae9Bz4KGIbS9LwVbu1ecqtwClex1RUxtXad2uLssvJvkEQ==",
       "license": "EUPL-1.2",
       "peer": true,
       "dependencies": {
-        "@utrecht/button-react": "3.0.1",
-        "@utrecht/calendar-css": "2.0.1",
+        "@utrecht/button-react": "3.0.2",
+        "@utrecht/calendar-css": "3.0.0",
         "clsx": "2.1.1",
         "date-fns": "4.1.0",
         "lodash-es": "4.18.1"
@@ -4553,57 +4562,32 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@utrecht/calendar-react/node_modules/@utrecht/button-react": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/button-react/-/button-react-3.0.1.tgz",
-      "integrity": "sha512-PlM0+KjOKoGVGsdSTsWASiO8dsYFbHMq8CD8JH3D9UxMRzJR5NCwY9hva9jGSr8KbIc+WImDEatyxtvMwMIxUg==",
+    "node_modules/@utrecht/calendar-react/node_modules/@utrecht/calendar-css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/calendar-css/-/calendar-css-3.0.0.tgz",
+      "integrity": "sha512-VM5Br7K/xf82tDf7BQXMVmPyDW3tVtWfKfe45FksVigihyDMjPKYZspTB1s5mkS53PX9vbeTvuMiECseiKoClQ==",
       "license": "EUPL-1.2",
-      "peer": true,
-      "dependencies": {
-        "@utrecht/button-css": "3.1.0",
-        "clsx": "2.1.1"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
+      "peer": true
     },
     "node_modules/@utrecht/card-css": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/card-css/-/card-css-1.0.1.tgz",
-      "integrity": "sha512-zklTHHTxmQ++/AYSLk5O7NRxNvd6Mzmch6vBcuts2Nj78UeGB2xvjzPlNnr5/FQV65Dm1QpP8bE71K2SANz7eA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/card-css/-/card-css-2.0.0.tgz",
+      "integrity": "sha512-xMeyg1uumoF4RgUm4CH0n/+++bSe1YpVQ/WQMhAi4nxtMzxcEf0FDkaPeZPZZJjEHc4YjsO8rxsZriP1mjiZ0g==",
       "license": "EUPL-1.2",
       "peer": true,
       "dependencies": {
-        "@utrecht/img-css": "2.0.1"
+        "@utrecht/img-css": "3.0.0"
       }
     },
     "node_modules/@utrecht/card-react": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@utrecht/card-react/-/card-react-0.0.4.tgz",
-      "integrity": "sha512-+1hsXn6k4ixXmeWZsi1GPRyErlcXzaN0cgLk5L1iQNVWnUBbkvYqbn76jF95MX2Jg4aiv6/zNdC59f10S/+g7Q==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@utrecht/card-react/-/card-react-0.0.5.tgz",
+      "integrity": "sha512-ss7c+LsKAXYose5JEkNbhu+6y7QNuyqTVJ6nE6gcj73pny1xicI+Hg1dg1WOs6v4FKpEMr0oV6J7htNTTlxDAQ==",
       "license": "EUPL-1.2",
       "peer": true,
       "dependencies": {
-        "@utrecht/card-css": "1.0.1",
-        "@utrecht/link-react": "1.0.10",
-        "clsx": "2.1.1"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@utrecht/card-react/node_modules/@utrecht/link-react": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@utrecht/link-react/-/link-react-1.0.10.tgz",
-      "integrity": "sha512-MAD/0bJN6Fxb6tHK5F/2vFD9wmqPw5dC98AgXriq6BnY4g9UPsM5NBgLHt8mMJ5gYF9hZzyxucqQVTetzgKsYQ==",
-      "license": "EUPL-1.2",
-      "peer": true,
-      "dependencies": {
-        "@utrecht/link-css": "2.0.1",
+        "@utrecht/card-css": "2.0.0",
+        "@utrecht/link-react": "1.0.11",
         "clsx": "2.1.1"
       },
       "peerDependencies": {
@@ -4616,14 +4600,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@utrecht/checkbox-css/-/checkbox-css-3.0.0.tgz",
       "integrity": "sha512-soXV+Ktoi3W31E6D0MRMv1kWhktKqmQtomwSWoTeBCxrrw5NoITc+AzKjhKnXTLCFR2VOpBa0JO0jrQC026GmQ==",
-      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/checkbox-react": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/@utrecht/checkbox-react/-/checkbox-react-1.0.13.tgz",
       "integrity": "sha512-W5DJHo4ZuzrQsRgSTMLI5KlwaKy4s0WGawcZag5WXt9KMNwEdIVWh3sjZP5iXiBEdc+ZBbi8dmDzdmPhBn0KvQ==",
-      "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
         "@utrecht/checkbox-css": "3.0.0",
@@ -4640,52 +4622,51 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@utrecht/custom-checkbox-css/-/custom-checkbox-css-3.0.0.tgz",
       "integrity": "sha512-jiMOiQKsxepEX8DYkGF5gBrFurH/MbZdPuuji/y6pJqUhrtf/meLeOUQ6/TmuXDTscCRsYFSTPI8htBQhDFXKA==",
-      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/code-block-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/code-block-css/-/code-block-css-2.0.1.tgz",
-      "integrity": "sha512-isBpsG7lN6qp1LdvBVmwVsTH2NlbzwAitgFzjH6Q60XyKhHB+cjW7irq43AaESKor1m2G1KdhQUZsbhkPjHzMw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/code-block-css/-/code-block-css-3.0.0.tgz",
+      "integrity": "sha512-1gFY1DtwUKNViSF3Ov6z50fE3A7d+amrUr1j5u23nBq5GbnbjMVGROhRnO/ZJPMpeV55GIlGwV7SoU30Hhfe1Q==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/code-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/code-css/-/code-css-2.0.1.tgz",
-      "integrity": "sha512-PEWcAYsBSEo/6GSOFQW/Bt7l7nT6yXn+QJoFJUFWtX6xRHuSu91m3ISbzmhozMQJX7mCl6mUXdHt7EVRUqlFKA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/code-css/-/code-css-3.0.0.tgz",
+      "integrity": "sha512-9W4ZduJYeyI1q0wM0/wtOIxoHg2V8shigJrcVEP5avI8zf+Ci/E3euXaQoUl8LBniPy1FU/mo+NvBTKE8bwMdw==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/color-sample-css": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@utrecht/color-sample-css/-/color-sample-css-2.0.2.tgz",
-      "integrity": "sha512-9Tc9ro0X4zU6oXLrIkj9lNYiYTHYRG02FtREP9Z0XrhqlfuAg2HkPts/GHgKj0ejlrfJOJP22VeMzuMfTJUhOg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/color-sample-css/-/color-sample-css-3.0.0.tgz",
+      "integrity": "sha512-isGpAYWINON0HACNZCceLSDJZ+YppDnqQoJTYsJlhda/9aD88zZiEw+12vQXAKC1WJC1R8quEQ9+A5VexCkIEw==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/column-layout-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/column-layout-css/-/column-layout-css-2.0.1.tgz",
-      "integrity": "sha512-HqK7QuMyftLSRvV7j+zG8szXbXi73rkWR776DsWQDg/SwebLaasjGuCTOgg7J7YTR0EK2+fj7s61R+utx7CDhg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/column-layout-css/-/column-layout-css-3.0.0.tgz",
+      "integrity": "sha512-/PQcnigr5RM2gyePxBY2OgA/Y6YDfGwQPw+C1BV97tOGkbMABBCEmH1xflcUbBtiCXqG93+efWaNzkqMVJBp7Q==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/combobox-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/combobox-css/-/combobox-css-2.0.1.tgz",
-      "integrity": "sha512-BUpeg4RNO/MezKQLMVdCIGCYlBvq9piKbsLwAROtQtEiGLWJlDqPL39OtCp2vZo1sesDUphVdXaYG9NiOrk8og==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/combobox-css/-/combobox-css-3.0.0.tgz",
+      "integrity": "sha512-BcANeFexV4sfRdes+T0p9WrqT0HrSluCxePT+8sHH/p6D36t4EMPax9yZcYzrbnNtKjlWOQEbWSE1X2mVw17kA==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/combobox-react": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@utrecht/combobox-react/-/combobox-react-0.0.11.tgz",
-      "integrity": "sha512-oA6Si8C7wD7sbU5RqoQBdY5tAYpJa6YwhvFMIchJjLdqmV8oGT+ZV8vWWbjtDiPPnZPWcZyO1U08mOd+fqQgDQ==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@utrecht/combobox-react/-/combobox-react-0.0.12.tgz",
+      "integrity": "sha512-tMZYj4qINFWnCw8A4Z+83B4OS7CPpkwBXvT+ZOXntud69I2Fh+wfqwzf7iu74AfMVIqVHKEG/vCQHTB6SW22WQ==",
       "license": "EUPL-1.2",
       "peer": true,
       "dependencies": {
-        "@utrecht/combobox-css": "2.0.1",
+        "@utrecht/combobox-css": "3.0.0",
         "clsx": "2.1.1"
       },
       "peerDependencies": {
@@ -4695,289 +4676,245 @@
       }
     },
     "node_modules/@utrecht/component-library-react": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@utrecht/component-library-react/-/component-library-react-13.1.0.tgz",
-      "integrity": "sha512-MarmH3cIyT+6Ckp83b1xYR7JpqNfrjI0n2lt1GQK6cqiy6DTuSODrFEnvDY92fwL4GHEMn4C0qi3g17THUqyew==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/component-library-react/-/component-library-react-14.0.0.tgz",
+      "integrity": "sha512-sIXjwzdgjJ3jxhTI5F0x1eZMvyarTAyxLfaA/wddubpEZBm8DlPiF4EwkcpB2Ja9mQz+t2ESl0LR5I8EqC4c6w==",
       "license": "EUPL-1.2",
       "peer": true,
       "dependencies": {
-        "@utrecht/accordion-css": "3.0.1",
-        "@utrecht/action-group-react": "1.1.4",
-        "@utrecht/alert-css": "3.0.1",
-        "@utrecht/alert-dialog-css": "2.0.1",
-        "@utrecht/alternate-lang-nav-css": "2.0.1",
-        "@utrecht/article-css": "2.0.1",
-        "@utrecht/backdrop-css": "2.0.2",
-        "@utrecht/badge-counter-css": "2.0.1",
-        "@utrecht/badge-list-css": "3.0.1",
-        "@utrecht/blockquote-css": "2.0.1",
-        "@utrecht/breadcrumb-nav-css": "2.1.0",
-        "@utrecht/button-group-react": "1.1.3",
-        "@utrecht/button-link-css": "2.0.1",
-        "@utrecht/button-react": "3.0.1",
-        "@utrecht/calendar-react": "1.1.2",
-        "@utrecht/card-css": "1.0.1",
-        "@utrecht/card-react": "0.0.4",
-        "@utrecht/checkbox-react": "1.0.12",
-        "@utrecht/code-block-css": "2.0.1",
-        "@utrecht/code-css": "2.0.1",
-        "@utrecht/color-sample-css": "2.0.2",
-        "@utrecht/column-layout-css": "2.0.1",
-        "@utrecht/combobox-react": "0.0.11",
-        "@utrecht/currency-data-css": "2.0.1",
-        "@utrecht/custom-checkbox-css": "2.0.1",
-        "@utrecht/data-badge-css": "2.0.1",
-        "@utrecht/data-badge-react": "1.0.7",
-        "@utrecht/data-list-css": "2.0.2",
-        "@utrecht/data-placeholder-css": "2.0.1",
-        "@utrecht/digid-button-css": "1.4.2",
-        "@utrecht/document-css": "2.0.1",
-        "@utrecht/drawer-css": "2.0.1",
-        "@utrecht/emphasis-css": "2.0.1",
-        "@utrecht/fieldset-react": "1.0.11",
-        "@utrecht/figure-css": "2.0.1",
-        "@utrecht/focus-ring-css": "3.1.0",
-        "@utrecht/form-field-checkbox-react": "1.1.4",
-        "@utrecht/form-field-description-react": "1.0.10",
-        "@utrecht/form-field-error-message-react": "1.0.10",
-        "@utrecht/form-field-react": "1.0.11",
-        "@utrecht/form-label-react": "1.0.10",
-        "@utrecht/form-toggle-css": "2.0.1",
-        "@utrecht/heading-1-css": "2.0.2",
-        "@utrecht/heading-2-css": "2.0.2",
-        "@utrecht/heading-3-css": "2.0.2",
-        "@utrecht/heading-4-css": "2.0.2",
-        "@utrecht/heading-5-css": "2.0.2",
-        "@utrecht/heading-6-css": "2.0.2",
-        "@utrecht/heading-group-css": "2.0.1",
-        "@utrecht/html-content-css": "2.1.0",
-        "@utrecht/iban-data-css": "2.0.1",
-        "@utrecht/icon-css": "3.0.1",
-        "@utrecht/img-css": "2.0.1",
-        "@utrecht/index-char-nav-css": "2.0.1",
-        "@utrecht/link-button-css": "2.0.1",
-        "@utrecht/link-list-css": "3.0.1",
-        "@utrecht/link-react": "1.0.10",
-        "@utrecht/link-social-css": "2.0.1",
-        "@utrecht/list-social-css": "2.0.1",
-        "@utrecht/listbox-react": "1.0.15",
-        "@utrecht/logo-button-css": "1.4.2",
-        "@utrecht/logo-css": "2.0.1",
-        "@utrecht/logo-image-css": "1.4.2",
-        "@utrecht/map-control-button-css": "3.0.1",
-        "@utrecht/map-marker-css": "2.0.1",
-        "@utrecht/mark-css": "2.0.2",
-        "@utrecht/multiline-data-css": "2.0.1",
-        "@utrecht/nav-bar-css": "2.0.1",
-        "@utrecht/nav-list-css": "1.3.2",
-        "@utrecht/number-badge-css": "3.0.1",
-        "@utrecht/number-data-css": "2.0.2",
-        "@utrecht/open-forms-container-css": "2.0.4",
-        "@utrecht/open-forms-container-react": "1.0.8",
-        "@utrecht/ordered-list-css": "3.0.1",
-        "@utrecht/page-content-css": "2.0.1",
-        "@utrecht/page-css": "2.0.1",
-        "@utrecht/page-footer-css": "3.0.2",
-        "@utrecht/page-header-css": "2.0.1",
-        "@utrecht/pagination-css": "2.0.3",
-        "@utrecht/paragraph-css": "3.0.1",
-        "@utrecht/pre-heading-css": "2.0.1",
-        "@utrecht/preserve-data-css": "2.0.1",
-        "@utrecht/radio-button-react": "1.0.11",
-        "@utrecht/rich-text-css": "2.1.0",
-        "@utrecht/search-bar-css": "3.0.2",
-        "@utrecht/select-css": "2.0.2",
-        "@utrecht/separator-css": "2.0.1",
-        "@utrecht/skip-link-css": "2.0.1",
-        "@utrecht/spotlight-section-css": "2.0.1",
-        "@utrecht/status-badge-css": "1.0.0",
-        "@utrecht/subscript-css": "2.0.1",
-        "@utrecht/superscript-css": "2.0.1",
-        "@utrecht/surface-css": "2.0.1",
-        "@utrecht/table-css": "2.0.3",
-        "@utrecht/table-of-contents-css": "1.0.2",
-        "@utrecht/textarea-css": "3.0.2",
-        "@utrecht/textbox-react": "1.0.14",
-        "@utrecht/top-task-link-css": "2.0.1",
-        "@utrecht/top-task-nav-css": "1.3.2",
-        "@utrecht/unordered-list-css": "2.0.1",
-        "@utrecht/url-data-css": "2.0.2",
-        "@utrecht/vega-visualization-css": "1.4.2",
+        "@utrecht/accordion-css": "4.0.0",
+        "@utrecht/action-group-react": "1.1.5",
+        "@utrecht/alert-css": "4.0.1",
+        "@utrecht/alert-dialog-css": "3.0.0",
+        "@utrecht/alternate-lang-nav-css": "3.0.0",
+        "@utrecht/article-css": "3.0.0",
+        "@utrecht/backdrop-css": "3.0.0",
+        "@utrecht/badge-counter-css": "3.0.0",
+        "@utrecht/badge-list-css": "4.0.0",
+        "@utrecht/blockquote-css": "3.0.0",
+        "@utrecht/breadcrumb-nav-css": "3.0.0",
+        "@utrecht/button-group-react": "1.1.4",
+        "@utrecht/button-link-css": "3.0.0",
+        "@utrecht/button-react": "3.0.2",
+        "@utrecht/calendar-react": "1.1.3",
+        "@utrecht/card-css": "2.0.0",
+        "@utrecht/card-react": "0.0.5",
+        "@utrecht/checkbox-react": "1.0.13",
+        "@utrecht/code-block-css": "3.0.0",
+        "@utrecht/code-css": "3.0.0",
+        "@utrecht/color-sample-css": "3.0.0",
+        "@utrecht/column-layout-css": "3.0.0",
+        "@utrecht/combobox-react": "0.0.12",
+        "@utrecht/currency-data-css": "3.0.0",
+        "@utrecht/custom-checkbox-css": "3.0.0",
+        "@utrecht/data-badge-css": "3.0.0",
+        "@utrecht/data-badge-react": "1.0.8",
+        "@utrecht/data-list-css": "3.0.0",
+        "@utrecht/data-placeholder-css": "3.0.0",
+        "@utrecht/digid-button-css": "2.0.0",
+        "@utrecht/document-css": "3.0.0",
+        "@utrecht/drawer-css": "3.0.0",
+        "@utrecht/emphasis-css": "3.0.0",
+        "@utrecht/fieldset-react": "1.0.12",
+        "@utrecht/figure-css": "3.0.0",
+        "@utrecht/focus-ring-css": "4.0.0",
+        "@utrecht/form-field-checkbox-react": "1.1.5",
+        "@utrecht/form-field-description-react": "1.0.11",
+        "@utrecht/form-field-error-message-react": "1.0.11",
+        "@utrecht/form-field-react": "1.0.12",
+        "@utrecht/form-label-react": "1.0.11",
+        "@utrecht/form-toggle-css": "3.0.0",
+        "@utrecht/heading-1-css": "3.0.0",
+        "@utrecht/heading-2-css": "3.0.0",
+        "@utrecht/heading-3-css": "3.0.0",
+        "@utrecht/heading-4-css": "3.0.0",
+        "@utrecht/heading-5-css": "3.0.0",
+        "@utrecht/heading-6-css": "3.0.0",
+        "@utrecht/heading-group-css": "3.0.0",
+        "@utrecht/html-content-css": "3.0.0",
+        "@utrecht/iban-data-css": "3.0.0",
+        "@utrecht/icon-css": "4.0.0",
+        "@utrecht/img-css": "3.0.0",
+        "@utrecht/index-char-nav-css": "3.0.0",
+        "@utrecht/link-button-css": "3.0.0",
+        "@utrecht/link-list-css": "4.0.0",
+        "@utrecht/link-react": "1.0.11",
+        "@utrecht/link-social-css": "3.0.0",
+        "@utrecht/list-social-css": "3.0.0",
+        "@utrecht/listbox-react": "1.0.16",
+        "@utrecht/logo-button-css": "2.0.0",
+        "@utrecht/logo-css": "3.0.0",
+        "@utrecht/logo-image-css": "2.0.0",
+        "@utrecht/map-control-button-css": "4.0.0",
+        "@utrecht/map-marker-css": "3.0.0",
+        "@utrecht/mark-css": "3.0.0",
+        "@utrecht/multiline-data-css": "3.0.0",
+        "@utrecht/nav-bar-css": "3.2.0",
+        "@utrecht/nav-list-css": "2.0.0",
+        "@utrecht/number-badge-css": "4.0.0",
+        "@utrecht/number-data-css": "3.0.0",
+        "@utrecht/open-forms-container-css": "3.0.0",
+        "@utrecht/open-forms-container-react": "1.0.9",
+        "@utrecht/ordered-list-css": "4.0.0",
+        "@utrecht/page-content-css": "3.0.0",
+        "@utrecht/page-css": "3.0.0",
+        "@utrecht/page-footer-css": "4.0.1",
+        "@utrecht/page-header-css": "3.0.1",
+        "@utrecht/pagination-css": "3.0.0",
+        "@utrecht/paragraph-css": "4.0.0",
+        "@utrecht/pre-heading-css": "3.0.0",
+        "@utrecht/preserve-data-css": "3.0.0",
+        "@utrecht/radio-button-react": "1.0.12",
+        "@utrecht/rich-text-css": "3.0.0",
+        "@utrecht/search-bar-css": "4.0.0",
+        "@utrecht/select-css": "3.0.0",
+        "@utrecht/separator-css": "3.0.0",
+        "@utrecht/skip-link-css": "3.0.0",
+        "@utrecht/spotlight-section-css": "3.0.1",
+        "@utrecht/status-badge-css": "2.0.0",
+        "@utrecht/subscript-css": "3.0.0",
+        "@utrecht/superscript-css": "3.0.0",
+        "@utrecht/surface-css": "3.0.0",
+        "@utrecht/table-css": "3.0.0",
+        "@utrecht/table-of-contents-css": "2.0.0",
+        "@utrecht/textarea-css": "4.0.0",
+        "@utrecht/textbox-react": "1.0.15",
+        "@utrecht/top-task-link-css": "3.0.0",
+        "@utrecht/top-task-nav-css": "2.0.0",
+        "@utrecht/unordered-list-css": "3.1.0",
+        "@utrecht/url-data-css": "3.0.0",
         "clsx": "2.1.1",
         "lodash.chunk": "4.2.0"
       },
       "peerDependencies": {
         "@babel/runtime": "^7.23.6",
         "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0",
-        "react-vega": "^7.6.0",
-        "vega": "^5.25.0"
-      },
-      "peerDependenciesMeta": {
-        "react-vega": {
-          "optional": true
-        },
-        "vega": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/button-react": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/button-react/-/button-react-3.0.1.tgz",
-      "integrity": "sha512-PlM0+KjOKoGVGsdSTsWASiO8dsYFbHMq8CD8JH3D9UxMRzJR5NCwY9hva9jGSr8KbIc+WImDEatyxtvMwMIxUg==",
-      "license": "EUPL-1.2",
-      "peer": true,
-      "dependencies": {
-        "@utrecht/button-css": "3.1.0",
-        "clsx": "2.1.1"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "*",
-        "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/checkbox-css": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@utrecht/checkbox-css/-/checkbox-css-2.0.2.tgz",
-      "integrity": "sha512-r4mfnI/so3sgi9cXJrvKtXPsMxA5swloNEvAB3ia9ny8SjbJVRwjNOj/IX6aFnT+eHOFUIitpf59NvDtMot1aA==",
+    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/alert-css": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@utrecht/alert-css/-/alert-css-4.0.1.tgz",
+      "integrity": "sha512-fTUsSyvyt07taBJCEqZyPpLmjZ0MJ9OzMiuVD4WTK30UPfyeM2L2pJfSe8kmOsMm+mvt8QtLHav+A43pRXcgZQ==",
       "license": "EUPL-1.2",
       "peer": true
     },
-    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/checkbox-react": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@utrecht/checkbox-react/-/checkbox-react-1.0.12.tgz",
-      "integrity": "sha512-WXtpzmF9jOT9qceD2823z3Pr+b2OTv7vlq5Q5as4pZpkhPOoCKjfUdvICt0dSyOs8I4FPh3JhENuMHqoGt2AcQ==",
+    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/button-link-css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/button-link-css/-/button-link-css-3.0.0.tgz",
+      "integrity": "sha512-ID0LOCPEeyvX2p9vfkJj3sMSPCrrhTTdh4zwNLBbsW0wZimShRLulMyq+6ZIBiTPcTlRDGw8H8AzJdfRn8eLVQ==",
       "license": "EUPL-1.2",
-      "peer": true,
-      "dependencies": {
-        "@utrecht/checkbox-css": "2.0.2",
-        "@utrecht/custom-checkbox-css": "2.0.1",
-        "clsx": "2.1.1"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
+      "peer": true
     },
-    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/fieldset-react": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@utrecht/fieldset-react/-/fieldset-react-1.0.11.tgz",
-      "integrity": "sha512-/8lje8gpfcLu3NEZTdwfQ1szMsfV0o5FbM+aNYHedkMpbljQKtXJeqoV64LrZhBmXpvUmnNQz1I5E+e04XhT+w==",
+    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/custom-checkbox-css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/custom-checkbox-css/-/custom-checkbox-css-3.0.0.tgz",
+      "integrity": "sha512-jiMOiQKsxepEX8DYkGF5gBrFurH/MbZdPuuji/y6pJqUhrtf/meLeOUQ6/TmuXDTscCRsYFSTPI8htBQhDFXKA==",
       "license": "EUPL-1.2",
-      "peer": true,
-      "dependencies": {
-        "@utrecht/form-fieldset-css": "2.0.2",
-        "clsx": "2.1.1"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
+      "peer": true
     },
-    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/form-field-description-react": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@utrecht/form-field-description-react/-/form-field-description-react-1.0.10.tgz",
-      "integrity": "sha512-tuK+ZdjnqxuWPPpi1O6dehzTmp49dTlE6/SlptILZDISIwS1ud1snwDqWjxAc5ytzdkf1wCJVeIFbAZVm1MMOQ==",
+    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/data-list-css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/data-list-css/-/data-list-css-3.0.0.tgz",
+      "integrity": "sha512-YEOrc3oAI1nayU7/OpeZ9SEIbw13demhiu2pbQUqgVSJSop8Hxx9oGrM0WsrDT1ltEbHeMKh5JMrt3lBnf0M8w==",
       "license": "EUPL-1.2",
-      "peer": true,
-      "dependencies": {
-        "@utrecht/form-field-description-css": "2.0.1",
-        "clsx": "2.1.1"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
+      "peer": true
     },
-    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/form-field-react": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@utrecht/form-field-react/-/form-field-react-1.0.11.tgz",
-      "integrity": "sha512-99FZaRXTEaE0TtkeU4/LvwH/YgQfT1ZhN/fM0XqPpvoxEOfPvBkspV4oIDGOKg9dMvrzX8N3F/YhOy1QNOBcLw==",
+    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/document-css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/document-css/-/document-css-3.0.0.tgz",
+      "integrity": "sha512-CMOuUNMW9BJoi8XpZyT2FnyWW6MlanykyN2vfi0f/s6GRpWHWc4Qe5vO+eNnEpY1XaXOcfjAbfQO3EDo93N8+A==",
       "license": "EUPL-1.2",
-      "peer": true,
-      "dependencies": {
-        "@utrecht/form-field-css": "2.0.2",
-        "clsx": "2.1.1"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
+      "peer": true
     },
-    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/form-label-react": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@utrecht/form-label-react/-/form-label-react-1.0.10.tgz",
-      "integrity": "sha512-oJhcTpVg38jRYEl2fOxvZAJHfaEyeQRTpQCxTZ6Mcv1dr1dhE259TwM03DtRXa+JTJoulxUG7vxTyclmxQwY3Q==",
+    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/heading-2-css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/heading-2-css/-/heading-2-css-3.0.0.tgz",
+      "integrity": "sha512-HLM1DoR9Gi8cYAAS8vTvV4ynlqNgWL4GcvmTk20sYw8h2rvomHK6F0B4QhL/IUML9ENjPGB2BhZUKaSAPEsTYQ==",
       "license": "EUPL-1.2",
-      "peer": true,
-      "dependencies": {
-        "@utrecht/form-label-css": "2.0.1",
-        "clsx": "2.1.1"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
+      "peer": true
     },
-    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/link-react": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@utrecht/link-react/-/link-react-1.0.10.tgz",
-      "integrity": "sha512-MAD/0bJN6Fxb6tHK5F/2vFD9wmqPw5dC98AgXriq6BnY4g9UPsM5NBgLHt8mMJ5gYF9hZzyxucqQVTetzgKsYQ==",
+    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/html-content-css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/html-content-css/-/html-content-css-3.0.0.tgz",
+      "integrity": "sha512-LE0qn7Y+/hdE0b1PbeaH6s24ZVAPEaxAF01x+tvMxOeDbmaThtJGkoPV6KcKdOpUZwAobc2ZONF7IIvtY8ycWw==",
       "license": "EUPL-1.2",
-      "peer": true,
-      "dependencies": {
-        "@utrecht/link-css": "2.0.1",
-        "clsx": "2.1.1"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
+      "peer": true
     },
-    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/radio-button-react": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@utrecht/radio-button-react/-/radio-button-react-1.0.11.tgz",
-      "integrity": "sha512-pMNR1Yyj82uSE06m3tzeyAMeL5jm2JDulR/MwsHn1rIpQylz0Lyj5597jvbRjw+CPvvj9cyoUe9DnBzx/6xkew==",
+    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/icon-css": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/icon-css/-/icon-css-4.0.0.tgz",
+      "integrity": "sha512-PR/Ass0xlXu67BjYp1Qi5VzCgVLHk93U2lmYfYq6xzOG+21beoIv8w7Y1nHV4XKWk82aJ/hwG4GrjbAsifReqw==",
       "license": "EUPL-1.2",
-      "peer": true,
-      "dependencies": {
-        "@utrecht/radio-button-css": "2.0.2",
-        "clsx": "2.1.1"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
+      "peer": true
     },
-    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/textbox-react": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@utrecht/textbox-react/-/textbox-react-1.0.14.tgz",
-      "integrity": "sha512-ouhtKqPUYLwgNETITFSehsWPxGwoOjs1oNBgIE1PamONrDhY8HtCdeC1IUo6VBAu1la1tIhz2XYq3VqV0bjEQg==",
+    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/ordered-list-css": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/ordered-list-css/-/ordered-list-css-4.0.0.tgz",
+      "integrity": "sha512-1Q3m1f4CEGR+BCqz1iZ6ii3/n5H+JzfSPuriEVMi5sKCiZxo7MoBbw1EPf9sUIS+L5VyFmxljiq5GLwfiLNmWA==",
       "license": "EUPL-1.2",
-      "peer": true,
-      "dependencies": {
-        "@utrecht/textbox-css": "3.1.1",
-        "clsx": "2.1.1"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "^7.23.6",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
+      "peer": true
+    },
+    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/paragraph-css": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/paragraph-css/-/paragraph-css-4.0.0.tgz",
+      "integrity": "sha512-ftT9x9HYbn6VIQ7RmD7YCSVzrfIjE83Ry1igSZGyQIECloB7aGs1TDU9k8knZUWYu2rG8eOgQrRabl1hds3q1A==",
+      "license": "EUPL-1.2",
+      "peer": true
+    },
+    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/select-css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/select-css/-/select-css-3.0.0.tgz",
+      "integrity": "sha512-zyjkPUBAC7Xy/XDpz4lNxHCF01vLiiXTIlLcpEN40Nf6bf0M6jMTWYvmp6NireuxLEb21NLK6Nq/XrpZEIXKhA==",
+      "license": "EUPL-1.2",
+      "peer": true
+    },
+    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/subscript-css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/subscript-css/-/subscript-css-3.0.0.tgz",
+      "integrity": "sha512-3F96wpTEqqLX9FWJp2yHYa2zdQ7P3MKkDnm9mobj/IFJOII1CAHXPdBzjm9M683slEkyHQ1AKe8sGFZr37z47g==",
+      "license": "EUPL-1.2",
+      "peer": true
+    },
+    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/superscript-css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/superscript-css/-/superscript-css-3.0.0.tgz",
+      "integrity": "sha512-5zVJpDzbO8EUbLN+5OdE/BVRmeB5kTRQRKzXmdUb34+kRXkSJqPR/2Tl1TGGYKsgkdprhii+gP/z1rC+AHzmtw==",
+      "license": "EUPL-1.2",
+      "peer": true
+    },
+    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/table-css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/table-css/-/table-css-3.0.0.tgz",
+      "integrity": "sha512-1rnKuUk4ScwsP7Svet2zETEoIwRrU/0rsyB2K5trKNwg8BJu+US3RPp01emXzqdJ+OfICAFcyjnZN1jxcnkV2g==",
+      "license": "EUPL-1.2",
+      "peer": true
+    },
+    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/textarea-css": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/textarea-css/-/textarea-css-4.0.0.tgz",
+      "integrity": "sha512-f4uSv+jjSpjgIiRxAFtKL4CJBHJQo1V6lBsAt8M+LGtIjKHJrIGaBUoO5ppsQFlzKQxKB5NNm0fYfCMEkQqlIA==",
+      "license": "EUPL-1.2",
+      "peer": true
+    },
+    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/unordered-list-css": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/unordered-list-css/-/unordered-list-css-3.1.0.tgz",
+      "integrity": "sha512-lJCc6RVXhx2+GWQjKh6rKXdoIla1+QN/+y/fkamTfmWhDfrGXb7/nFL7C+dW6RPLlUaM7Y3TNw+RtIiHeaUpTQ==",
+      "license": "EUPL-1.2",
+      "peer": true
+    },
+    "node_modules/@utrecht/component-library-react/node_modules/@utrecht/url-data-css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/url-data-css/-/url-data-css-3.0.0.tgz",
+      "integrity": "sha512-0sx9tvBirf8T2XSUxmRM8MN1BoZa4FtTkdraEMVgmdRI72SN45ekgcWKYF9ZKiDNAniyOFw6NTmWgqc1k+LPcw==",
+      "license": "EUPL-1.2",
+      "peer": true
     },
     "node_modules/@utrecht/currency-data-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/currency-data-css/-/currency-data-css-2.0.1.tgz",
-      "integrity": "sha512-RjbY93rP5+LsNAlcA6krrzt/lwjtI+gMALqEsw9srHXJQvF3DcJUxlR/fUfS7H6EdMy26OxRJGJ+XQ4wL6P4hA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/currency-data-css/-/currency-data-css-3.0.0.tgz",
+      "integrity": "sha512-dAhsKa5ckKsUbS7mDSih2o4LSWWkl1peJcmT4hAdLYt1Ehq/kWRHAAp4R+QrY46MHF4SUh8OBIxyfVAZwGUQ0w==",
       "license": "EUPL-1.2",
       "peer": true
     },
@@ -4985,23 +4922,24 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/custom-checkbox-css/-/custom-checkbox-css-2.0.1.tgz",
       "integrity": "sha512-Gt7D6cnCfotYK0P/VeTcGksIhTrCYo3PEx1LxPnj9X99uMNg57O13ZRRaR/7wqPHsdiUKD7B82pQ1FdjAuY7lA==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/data-badge-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/data-badge-css/-/data-badge-css-2.0.1.tgz",
-      "integrity": "sha512-UMisFH+47SvLFKicA+Em9el8ksyfoO2UtNZHODSL6qf+Bb33QQhGHnnBvcuKg1LTtiK1YdjHxVlnk05wCuFSqQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/data-badge-css/-/data-badge-css-3.0.0.tgz",
+      "integrity": "sha512-Xl1j24b3en+Wq9byYtVQqz3JOxdaV6jkt2IIqI+jx98Od10aTm9geJ8Q+IQWohY4jFv6GIcdEtMsbJZfbibB1Q==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/data-badge-react": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@utrecht/data-badge-react/-/data-badge-react-1.0.7.tgz",
-      "integrity": "sha512-+RLDmI1tWBIloMA2Qt1bROOfXgssfu5H2mKKO5RWwqkFRtGXsvvUyLYv1TFaLYQCRZFzGjXjwVN97zrbIUaPFg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@utrecht/data-badge-react/-/data-badge-react-1.0.8.tgz",
+      "integrity": "sha512-JgFIW+GQ36/2Z5R+qUJz9VO1/ZTS+tWl7O7olyFwOG7lslb5EFrzOQ/qQUXecyty3s9BXdvpZPtIYuE+d2kYWw==",
       "license": "EUPL-1.2",
       "peer": true,
       "dependencies": {
-        "@utrecht/data-badge-css": "2.0.1",
+        "@utrecht/data-badge-css": "3.0.0",
         "clsx": "2.1.1"
       },
       "peerDependencies": {
@@ -5014,19 +4952,20 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/data-list-css/-/data-list-css-2.0.2.tgz",
       "integrity": "sha512-2++bYtdwg0+xhU6hJ2iFoghXEBEQbLUY96fIOb73Av6ER5SsbdKw5/lxNwBLYk+b8m5O3Nv92Dfai/k2eqNGvQ==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/data-placeholder-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/data-placeholder-css/-/data-placeholder-css-2.0.1.tgz",
-      "integrity": "sha512-eM81866Pcnpdi+6B6AvCffJjfrsrmpNIZpGScrS4qTGJwePtsnd76bT6NB1eP3NFkA/Ptnfvs4UjFAO3KAK4Zg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/data-placeholder-css/-/data-placeholder-css-3.0.0.tgz",
+      "integrity": "sha512-3CxNyMiOGmvSl2AM+nW3+r01bDKsevKsZftbFK53nXnw7w07wEoEs3o1x00bhGAx9T65a4jc11AF7wfXRlVrdg==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/digid-button-css": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@utrecht/digid-button-css/-/digid-button-css-1.4.2.tgz",
-      "integrity": "sha512-lE0/KipLVHaxb7YeZC3YPqSiSaDVyCkzSWmxLjs8k5ghzId8WI4vG8P42716gDBh9tsfdX0kRcVFdh5KerSiyw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/digid-button-css/-/digid-button-css-2.0.0.tgz",
+      "integrity": "sha512-/FynGNe2+BuQruh5K2b6pUqjLrYSVbSv867qNhxqPC/xlUTuO++drqdYFMZppQTwlLodhv3rTcZ8ghDno9+d7A==",
       "license": "EUPL-1.2",
       "peer": true
     },
@@ -5034,19 +4973,20 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/document-css/-/document-css-2.0.1.tgz",
       "integrity": "sha512-j4KLusBIGqB6SQocBtGSm5zHfCY4nvwG5gxzh3kOLdPuLGj6scaUxN3AahJi1cO/o2ciOyFxBbDYk0LJVq1Mdg==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/drawer-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/drawer-css/-/drawer-css-2.0.1.tgz",
-      "integrity": "sha512-4YysV31TmYGK8mLIF0ZLnUsc7j+02TylXJVZrMDQzisasEUbh8FXhHNbGTyZxlmGaFfjMtblCldp/UnsLkFH2Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/drawer-css/-/drawer-css-3.0.0.tgz",
+      "integrity": "sha512-29ot5ioWLq0/Se8fishj6b+PWQoiPXKHJ3xUJnVSHsj0cuGVA+tqt96ElOEloS39acuyvMt2SsqRtcR7yLmtXA==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/emphasis-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/emphasis-css/-/emphasis-css-2.0.1.tgz",
-      "integrity": "sha512-lnFb2l7puRIMKCy/4w9Zvg1Ipi6rSaJMyxyG7q30EH6kUpY/R4NYZYgLTkB5gzvPGBddfywvl20c590sYd9dHQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/emphasis-css/-/emphasis-css-3.0.0.tgz",
+      "integrity": "sha512-Euo9xYRnM+jwn+IqBEtjNhTVbSPELFeQOxC5PL7rC0YDJ5SS8M9fxem/SezCdxe4HfBEaBu3C9ITjgaZXaAljw==",
       "license": "EUPL-1.2",
       "peer": true
     },
@@ -5054,7 +4994,6 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@utrecht/fieldset-react/-/fieldset-react-1.0.12.tgz",
       "integrity": "sha512-TrCs1KCjpNIHVZxpu9aIwXBrTdQaj9SfMiMXr8IlacAdky94PusH+Mok5IiljvVL+j+xusB8L6uoJ4nFL4jrSg==",
-      "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
         "@utrecht/form-fieldset-css": "3.0.0",
@@ -5070,107 +5009,34 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@utrecht/form-fieldset-css/-/form-fieldset-css-3.0.0.tgz",
       "integrity": "sha512-ozmBMq89z/tNzqRB/jgVBLjjUBOeYswBReLT6TpUtkci6aZcAmni+McTnEE512pV9mvSIptrgsTxeTxySRorug==",
-      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/figure-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/figure-css/-/figure-css-2.0.1.tgz",
-      "integrity": "sha512-+mAPgdcd+0ZrQZR74h4VdDsxqkfs3e1DYDhgfcu9qAmQfb1MfSz8HkHFkZFtkuQYd854UsHeTTVq3UkwZTM04g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/figure-css/-/figure-css-3.0.0.tgz",
+      "integrity": "sha512-H6UxHSCjcg5yvfph4JTkxIVpW/HPf+Zd1/0cmaeb9ceX/+gsNQ+2gkV72LhPfRhwWCkqXzQy65wpSz1jMBsttA==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/focus-ring-css": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@utrecht/focus-ring-css/-/focus-ring-css-3.1.0.tgz",
-      "integrity": "sha512-KIymUn473aRCW0eu/ZS4dEMKZF9mPE+npfoEsfKKGBTX51feZ7HiLnB7f4xqrxIfmd2Z3zxYtSxtvMgidSHA6Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/focus-ring-css/-/focus-ring-css-4.0.0.tgz",
+      "integrity": "sha512-Gl1Bo5rmA2AWhgWFxX37pbrAIwjwPEdT7qkE2qXN2Gg68z62Sgkz4XoW15TE4GsnadfShP5kx7eNS3Ee2MDWew==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/form-field-checkbox-react": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@utrecht/form-field-checkbox-react/-/form-field-checkbox-react-1.1.4.tgz",
-      "integrity": "sha512-D5wbgcOmyUPIvZwN087k0d60kn25IV+43CgKmn4NssRonfVKFECEXXo3aZ53TfyVtTWRAyDJK9xzWpy/7KCs5Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@utrecht/form-field-checkbox-react/-/form-field-checkbox-react-1.1.5.tgz",
+      "integrity": "sha512-Lce0URWWiQlX40kVLo+AZ+kSCVqCEFNw+NgDVP47T1gYLXAlpNgSZaCIdahuTJ9hKRmZjMmIojVJalmCe55mcg==",
       "license": "EUPL-1.2",
       "peer": true,
       "dependencies": {
-        "@utrecht/checkbox-react": "1.0.12",
-        "@utrecht/form-field-description-react": "1.0.10",
-        "@utrecht/form-field-error-message-react": "1.0.10",
-        "@utrecht/form-field-react": "1.0.11",
-        "@utrecht/form-label-react": "1.0.10",
-        "clsx": "2.1.1"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@utrecht/form-field-checkbox-react/node_modules/@utrecht/checkbox-css": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@utrecht/checkbox-css/-/checkbox-css-2.0.2.tgz",
-      "integrity": "sha512-r4mfnI/so3sgi9cXJrvKtXPsMxA5swloNEvAB3ia9ny8SjbJVRwjNOj/IX6aFnT+eHOFUIitpf59NvDtMot1aA==",
-      "license": "EUPL-1.2",
-      "peer": true
-    },
-    "node_modules/@utrecht/form-field-checkbox-react/node_modules/@utrecht/checkbox-react": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@utrecht/checkbox-react/-/checkbox-react-1.0.12.tgz",
-      "integrity": "sha512-WXtpzmF9jOT9qceD2823z3Pr+b2OTv7vlq5Q5as4pZpkhPOoCKjfUdvICt0dSyOs8I4FPh3JhENuMHqoGt2AcQ==",
-      "license": "EUPL-1.2",
-      "peer": true,
-      "dependencies": {
-        "@utrecht/checkbox-css": "2.0.2",
-        "@utrecht/custom-checkbox-css": "2.0.1",
-        "clsx": "2.1.1"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@utrecht/form-field-checkbox-react/node_modules/@utrecht/form-field-description-react": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@utrecht/form-field-description-react/-/form-field-description-react-1.0.10.tgz",
-      "integrity": "sha512-tuK+ZdjnqxuWPPpi1O6dehzTmp49dTlE6/SlptILZDISIwS1ud1snwDqWjxAc5ytzdkf1wCJVeIFbAZVm1MMOQ==",
-      "license": "EUPL-1.2",
-      "peer": true,
-      "dependencies": {
-        "@utrecht/form-field-description-css": "2.0.1",
-        "clsx": "2.1.1"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@utrecht/form-field-checkbox-react/node_modules/@utrecht/form-field-react": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@utrecht/form-field-react/-/form-field-react-1.0.11.tgz",
-      "integrity": "sha512-99FZaRXTEaE0TtkeU4/LvwH/YgQfT1ZhN/fM0XqPpvoxEOfPvBkspV4oIDGOKg9dMvrzX8N3F/YhOy1QNOBcLw==",
-      "license": "EUPL-1.2",
-      "peer": true,
-      "dependencies": {
-        "@utrecht/form-field-css": "2.0.2",
-        "clsx": "2.1.1"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@utrecht/form-field-checkbox-react/node_modules/@utrecht/form-label-react": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@utrecht/form-label-react/-/form-label-react-1.0.10.tgz",
-      "integrity": "sha512-oJhcTpVg38jRYEl2fOxvZAJHfaEyeQRTpQCxTZ6Mcv1dr1dhE259TwM03DtRXa+JTJoulxUG7vxTyclmxQwY3Q==",
-      "license": "EUPL-1.2",
-      "peer": true,
-      "dependencies": {
-        "@utrecht/form-label-css": "2.0.1",
+        "@utrecht/checkbox-react": "1.0.13",
+        "@utrecht/form-field-description-react": "1.0.11",
+        "@utrecht/form-field-error-message-react": "1.0.11",
+        "@utrecht/form-field-react": "1.0.12",
+        "@utrecht/form-label-react": "1.0.11",
         "clsx": "2.1.1"
       },
       "peerDependencies": {
@@ -5183,19 +5049,20 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/form-field-css/-/form-field-css-2.0.2.tgz",
       "integrity": "sha512-bKdUBkTgTz+fIoFM+I+lzGKDje/o9K32TqPaPKljcDWwggdcqPwBSZ9Z5haqelAR0avgsZWjEyWToPZ7Vwj5Ww==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/form-field-description-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/form-field-description-css/-/form-field-description-css-2.0.1.tgz",
       "integrity": "sha512-M2hYlmEBykGPHSjm46kMkSsuhXTCZgBglQDcW+pWT1KS1rAapqxTDelxjlh2uU7TXLtXWnoeA5C3Gv1nYxUjkA==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/form-field-description-react": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@utrecht/form-field-description-react/-/form-field-description-react-1.0.11.tgz",
       "integrity": "sha512-OAOxWsY5Sh22WEbyG3hR+yzOEx+9KZ8vYF0JfmPUOgyr6yEnErluL+kS39cT4zBwMMzoT0KnvTqjii+SXdSRlQ==",
-      "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
         "@utrecht/form-field-description-css": "3.0.0",
@@ -5211,24 +5078,23 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@utrecht/form-field-description-css/-/form-field-description-css-3.0.0.tgz",
       "integrity": "sha512-DPgtTGLp8VscoNzKHwNY7U2t3Eq3hYuvbATSp7IMH9qOOnkUCl7Qx3bHPleKUHdbgdewziwjN4y6h5kCWN1EoQ==",
-      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/form-field-error-message-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/form-field-error-message-css/-/form-field-error-message-css-2.0.1.tgz",
-      "integrity": "sha512-4Oe5aIgMNkKXHcCZ86z+/ClSbaDxZ4atxdqgFPU1mi1L7P07QK2yatUGvjOlV1h4dwXMyl2zcNkxCn62wPhJvw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/form-field-error-message-css/-/form-field-error-message-css-3.0.0.tgz",
+      "integrity": "sha512-pKGEnSQLOKXd5ywalbo0w46GLzbCDRHjlfWs3jpWfYQ9A9XNUxOdpXIVV/rxOklrHzY9et/w42q+ShVQ5PvyAg==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/form-field-error-message-react": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@utrecht/form-field-error-message-react/-/form-field-error-message-react-1.0.10.tgz",
-      "integrity": "sha512-RJxKw9J1qcoyZ7uGArDQirKcoBTWXoDULXe2W8OzA3ug2hKN4MM1S06HoxSDLIjqvLdjklrPFe3ffBkuIytg9g==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@utrecht/form-field-error-message-react/-/form-field-error-message-react-1.0.11.tgz",
+      "integrity": "sha512-cvdCi6Dx6p0EB4NwoIHtkrVDzgWiadrxKeVryGPB4k+2naYOeIFk/G1x2X/s/SgqYdqtcsNicr1mfaJlA1YJKQ==",
       "license": "EUPL-1.2",
       "peer": true,
       "dependencies": {
-        "@utrecht/form-field-error-message-css": "2.0.1",
+        "@utrecht/form-field-error-message-css": "3.0.0",
         "clsx": "2.1.1"
       },
       "peerDependencies": {
@@ -5241,7 +5107,6 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@utrecht/form-field-react/-/form-field-react-1.0.12.tgz",
       "integrity": "sha512-reUzvVKyWsEACl1snediMjwYNASmCezMg45Qpr9PgmCeJJo85aZkHOhvWwViThdLBY43UGBEivfPfIvZfFmjsQ==",
-      "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
         "@utrecht/form-field-css": "3.0.0",
@@ -5257,26 +5122,26 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@utrecht/form-field-css/-/form-field-css-3.0.0.tgz",
       "integrity": "sha512-zcC/iY7yukxW67ZLZ3bnRJFFqo1VzPrXLVrgwKG+10j9lcNhmyTwFdzFG5iUR40y4dsMHAVDYuBGCbIIR9Mlhw==",
-      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/form-fieldset-css": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/form-fieldset-css/-/form-fieldset-css-2.0.2.tgz",
       "integrity": "sha512-uXEqBItdo2C4Hrf1ybuOg/uv42r50LR9KSoAXw35TNSBWsO6aCXzDjPZJba5ADBAJkWGNeagc1YXpyHKVTIudg==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/form-label-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/form-label-css/-/form-label-css-2.0.1.tgz",
       "integrity": "sha512-ghkVY1auCGoKaaFzAIPGetXjJE1H1ZXPYnW39xZfhIQjKiUh4NW0uvLHj9sZC24YHGwuuiJmtKGJwTER0X45EA==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/form-label-react": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@utrecht/form-label-react/-/form-label-react-1.0.11.tgz",
       "integrity": "sha512-sd3wSqxLwRDfsKElXHmlxiirV6J2Jp6mQCeXJyDUbLaUhbKfehIGfaH9FHp3r+PXm1MJYbwyqbNm9Qagvix55g==",
-      "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
         "@utrecht/form-label-css": "3.0.0",
@@ -5292,20 +5157,19 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@utrecht/form-label-css/-/form-label-css-3.0.0.tgz",
       "integrity": "sha512-m3cpyWSXbRIKvI1Ij2/0TJf04J83Ke8nGWxiRgakyIV7Pk2PkB61DDchnqlcr9HK/MzBu69/NSuvT68ZNu68XA==",
-      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/form-toggle-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/form-toggle-css/-/form-toggle-css-2.0.1.tgz",
-      "integrity": "sha512-VHa8KXKfAo3gr53ZCxYute0GPACDTrM9fdSmtakmS9Iu9s6niJgkkZmhFfNY+X5N75rEQiI+aTmFyA5TM/xh+g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/form-toggle-css/-/form-toggle-css-3.0.0.tgz",
+      "integrity": "sha512-5/NYFxuRhc4TSF/occvMMD06vs5UKMein1dijSVHPJhrrjn7tGMftJba0UpOg7/PxvZYs0TZjeRLFP40H0VVOA==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/heading-1-css": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@utrecht/heading-1-css/-/heading-1-css-2.0.2.tgz",
-      "integrity": "sha512-QKTepHh+Ow5ao37gJxHlMTfH11UQ1Cr0aVao4/StIWO7WNwxba5VWVgYyLpcrToDSEX6FFgWKalWPQ96hVIOjQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/heading-1-css/-/heading-1-css-3.0.0.tgz",
+      "integrity": "sha512-tYBOuRXAGblqBnQX9fQ70cuQLCxTrdZJOLPrmiFdSAUvfjacE02Cx9XcHA4wp18biPR0HF/MBQpYCFej/u0oMg==",
       "license": "EUPL-1.2",
       "peer": true
     },
@@ -5313,40 +5177,41 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/heading-2-css/-/heading-2-css-2.0.2.tgz",
       "integrity": "sha512-lMWkDlon+ZK8RUD7XJnowdaPot+fXg8re1F1m9rGjogT0/PpDnPv8y/76cBv6UqQFE940soq7ONdeH8KhHStUg==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/heading-3-css": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@utrecht/heading-3-css/-/heading-3-css-2.0.2.tgz",
-      "integrity": "sha512-jl5QLdtrcwaCN/WnObpkPisHwyyuqurgihp0JP6dL0wZz5OtpWAsTkMCDJPyEwXHZ9ozpdWl26xiTE/ukno0Ng==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/heading-3-css/-/heading-3-css-3.0.0.tgz",
+      "integrity": "sha512-0EfdTu8ca3gVFfbD2lbR8XTAJhpbpYU3W2rSoafj9cgsCIXpuDKemBPHE1Iu0wJQejR4qF9TmGabxBnpo/b6Ig==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/heading-4-css": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@utrecht/heading-4-css/-/heading-4-css-2.0.2.tgz",
-      "integrity": "sha512-P5RYGfDEdYB6vMqBUd7Wlvz2sP5cESGVjYiWCSdAtVusvzCnTHb5JkiLaZcobSpOMFJXcOFZGGRLmnbEwTtr0Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/heading-4-css/-/heading-4-css-3.0.0.tgz",
+      "integrity": "sha512-gzG336XDpVEi3pGGFPLrh2+YIP113Ky2PuyBMb3XonmQRPK/prOHZEwymKtuxEmSvHBBpjNVSvMd5tvsf/COAw==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/heading-5-css": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@utrecht/heading-5-css/-/heading-5-css-2.0.2.tgz",
-      "integrity": "sha512-9frKz5wIY7PzInga6gyXRCRRPVBSnuuhLM5w5bo+3fCjOVtuqwTBZifNV1yqJrarxnJhB1BYsxJFvPTFqtz/dQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/heading-5-css/-/heading-5-css-3.0.0.tgz",
+      "integrity": "sha512-ntksbd9Tm0FTWz5BwKOLp1BVxNhLgGMjNxa/gy1+AfnsiIZqdhEuAD9yP+0eme2AJbDiVt+SaxkRVN9EjVGUtQ==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/heading-6-css": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@utrecht/heading-6-css/-/heading-6-css-2.0.2.tgz",
-      "integrity": "sha512-XIEta/MnPOz8ec2lxeA7Ix+NjFNLAv3FSCZ9XnTPMnDGeNotk/0nqiTiEzXrFnP/Z2AD/yIcWyureXUpxorZ1g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/heading-6-css/-/heading-6-css-3.0.0.tgz",
+      "integrity": "sha512-lDItxhs87213BFRJusIHvFkzwJygtMfOPjhIMXQzRKIdLLszxBXVFK35avvKylqIv78/5AZXUhD6n8XiqaaM5A==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/heading-group-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/heading-group-css/-/heading-group-css-2.0.1.tgz",
-      "integrity": "sha512-MgeMBWVcmLXG4bZRtneSdBvf0cq1PR9mBHSS5ldPKCfJZ0Xdl2bOH9CMah6XABUL5reyvw55JbE0zvJoHyKvmA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/heading-group-css/-/heading-group-css-3.0.0.tgz",
+      "integrity": "sha512-BxSO587NOowjuGba112aSeumLwNw86g9W5OBOsKZ+Lr63LkzAaK4yBeMd7nxzn4t7BUu3T1CL3PLBr/WkVXJ8A==",
       "license": "EUPL-1.2",
       "peer": true
     },
@@ -5354,12 +5219,13 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@utrecht/html-content-css/-/html-content-css-2.1.0.tgz",
       "integrity": "sha512-YG3alKhPumUvBx239ZD+XgF+4UtU1maLYRbHTwKootfx9yITidQN2PeYeZwcMBwLGr2gn/Ajfoy/zyevNTWm9g==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/iban-data-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/iban-data-css/-/iban-data-css-2.0.1.tgz",
-      "integrity": "sha512-K7kcT1w9JRPLQWWjmj7O0UNDBcTMOv1gAzDWhE7hQwxcbwDrL/e4DAcrrmR7bicH9soParrDTr+wEq4OxNJl8Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/iban-data-css/-/iban-data-css-3.0.0.tgz",
+      "integrity": "sha512-2cUb1jTxsD8IPBLPOkCrSZOviKpdLFPB1cJVlpvu1K1OLAViPLm4Q+jBc5/qEl9ExeCL8/7zHSkf9c3afgW3Ng==",
       "license": "EUPL-1.2",
       "peer": true
     },
@@ -5367,26 +5233,27 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/icon-css/-/icon-css-3.0.1.tgz",
       "integrity": "sha512-dZdJ3jH4/ThxOTni743cIYc/zBe7o18j6uHOJxYjydfL/kSivcLrmVwiIJq6T18bbKAKjLceYJ+SiL93Pnt+tw==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/img-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/img-css/-/img-css-2.0.1.tgz",
-      "integrity": "sha512-G5D1Nc7SlQeUgKic14s7VdsMcXxSquyS0INNmq79ejf73l6GNXY7E+Gag3JwyOopHUAKqW1u5fKZG00bySPabA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/img-css/-/img-css-3.0.0.tgz",
+      "integrity": "sha512-nGnawGURYB03J20BWrG6ILri6KW5wdK1vevpJ76bMMZFSFFd+CDjmZXeaBBLLz0EgcYkQj3gAEgXr28gBiawyw==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/index-char-nav-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/index-char-nav-css/-/index-char-nav-css-2.0.1.tgz",
-      "integrity": "sha512-/sCn0vamJZaFDYx0hyFgKSVJgAndGtMsDRs287vR5fkJzGjeNoFH+cigYukIpjj/55bvFVjuLdFWT9toGiIkVA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/index-char-nav-css/-/index-char-nav-css-3.0.0.tgz",
+      "integrity": "sha512-kJOmq32Q7NmHE3/3ORwqAA16vYLkLvFETfL2i7p0g+nQ6Nej640kiljatBn1M2NUVSc04BLp2DyeMGvhojTyJA==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/link-button-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/link-button-css/-/link-button-css-2.0.1.tgz",
-      "integrity": "sha512-7HxgKyp7IkV0PAZb90ASvr9Iz+BPMw4yqpiN3IiD5HdPzTwQY8CjW7k4/hFZXrh/MMwnRUwcrDLJsbCLSfyKrw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/link-button-css/-/link-button-css-3.0.0.tgz",
+      "integrity": "sha512-eFdofIw3yQnSlvfJVb7umYh8Ia45Lw51V9QP/eCfkliTWIN/G5iQM3T8gue8G2fCLUnIZw4xY7c3MgqRD6DhoA==",
       "license": "EUPL-1.2",
       "peer": true
     },
@@ -5394,12 +5261,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/link-css/-/link-css-2.0.1.tgz",
       "integrity": "sha512-2mpaFeKybBeL+qIvJ73UC0jtwhn0IBM3vn8BD9OTwYQK6djY0tVwQwpouDWrzPRU169swp8BPllMU19A0xfyZA==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/link-list-css": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/link-list-css/-/link-list-css-3.0.1.tgz",
-      "integrity": "sha512-/+pNmHFGadl/zVy0I3G6TVNWB3EuqRLvjsoBL7ue9+wJeye4LqDcweYgdFKm7wFcN4Tci479j21fZ63IK4KlXA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/link-list-css/-/link-list-css-4.0.0.tgz",
+      "integrity": "sha512-s/ZT1bj/I2pkjvnLBNdLDqBgOnQQkI6CyfXOxnYXdCICKBoeK1z5XqrWrH1TmjapUo2ddchQUefRjBFq0uweJA==",
       "license": "EUPL-1.2",
       "peer": true
     },
@@ -5407,7 +5275,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@utrecht/link-react/-/link-react-1.0.11.tgz",
       "integrity": "sha512-ffzDkfhxRanw4G0PR7fKzeH122ujHajnsJkhIVW24+mP0shSiDlFVHkKjgk99vX6Iun55pm2RVZxk55oMaMVdA==",
-      "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
         "@utrecht/link-css": "3.0.0",
@@ -5423,38 +5290,37 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@utrecht/link-css/-/link-css-3.0.0.tgz",
       "integrity": "sha512-JlH8HIH2mgtuEDnNJemEfiHLUq04PvFryI8NDzz3edM2OQED8UPeRXn+CPkNsz9kjFN3ZdqlVw3N1O67GYIwNg==",
-      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/link-social-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/link-social-css/-/link-social-css-2.0.1.tgz",
-      "integrity": "sha512-njEvSkMm9Nvp4Bzxxly/WY8qMC3KFgWFT2K/z72JaTmbVUuqfYmRhw7HgZEPhRCKdFZ5BhI4T83Cbw0uHxLvgg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/link-social-css/-/link-social-css-3.0.0.tgz",
+      "integrity": "sha512-2301XjMNB9NRB46SWbFG1ogLOsvmRvGwbhbL6l/q7HpXA1Ir61KlbCyztDQ7pTGPXb8xniN4Xa/d/4+oVh2JVQ==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/list-social-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/list-social-css/-/list-social-css-2.0.1.tgz",
-      "integrity": "sha512-VQiJRl00582GpBfoDV3UkURUUuo3tvdL0K9k8IXCA6tOuLIntf3n8zMB+fV2UciEPkDt0J/1qlXiyhtYz6hs4g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/list-social-css/-/list-social-css-3.0.0.tgz",
+      "integrity": "sha512-28XPEk9VP+2A9B1GgXvEeEN9ET9D53N/PX6ZhvxgCg3nYepE4WtkXxAqbJlWSd8WE8lU0HS/tlTp0c24pquatA==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/listbox-css": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/listbox-css/-/listbox-css-2.1.1.tgz",
-      "integrity": "sha512-GF1/Ed5Cx9wf9LffMgg5gS2v9WoR+tQbw9IwRfkVhwz4zjQ1TuoT3D7MdcxsEffFj4oJB80ZQq0LTUlcm0JK3Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/listbox-css/-/listbox-css-3.0.0.tgz",
+      "integrity": "sha512-0niDtSsZIzc4yJ3JJM8/hGdpwFdtaqxR/ixBteRVJ1M6k6IaGoGbFeLcZ8XQjyYFe20ULVOLVbbjCBSIIlhXWg==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/listbox-react": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@utrecht/listbox-react/-/listbox-react-1.0.15.tgz",
-      "integrity": "sha512-PgU4RFOOEHyunke2ghPcgVqmev7awZEpX9lJMp0l4yC7jkvNZHibhute9Wddbtl/pYfV1a2cgOPrmzNEzMhM9Q==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@utrecht/listbox-react/-/listbox-react-1.0.16.tgz",
+      "integrity": "sha512-NeW35ya98ZO5S6rCQInYilPUMjeEl4bz4PoRpq4bvzc9xVtiuHB9tPZkzjSCHAiKncBN7Hl3H6e8HXc+IXkIQg==",
       "license": "EUPL-1.2",
       "peer": true,
       "dependencies": {
-        "@utrecht/listbox-css": "2.1.1",
+        "@utrecht/listbox-css": "3.0.0",
         "clsx": "2.1.1"
       },
       "peerDependencies": {
@@ -5464,101 +5330,108 @@
       }
     },
     "node_modules/@utrecht/logo-button-css": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@utrecht/logo-button-css/-/logo-button-css-1.4.2.tgz",
-      "integrity": "sha512-urW6k/UWoHYdaLbr/a3qvIhMzIxCOfZYyWkqg3qmBPyxe42hWACXmjy63lbN2WfRZiV7YZKAtGRyDSQ5t5xM5w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/logo-button-css/-/logo-button-css-2.0.0.tgz",
+      "integrity": "sha512-l538OJy5h/4LA8BwuqgmTARxDZbGdzm0sNkaBpBOJMaKhbV0FdYBKLhYKRh/AYrQjBMbwSIHB0xhGlDVJ3sioQ==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/logo-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/logo-css/-/logo-css-2.0.1.tgz",
-      "integrity": "sha512-G2WyPM1Y1UnuQTodTcQ5wXGKm7gz4Wnre6O211ra4CAxhRfIXSxTUiW9waVHrkBOz+rxDy0S57gsBabAOiLGxQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/logo-css/-/logo-css-3.0.0.tgz",
+      "integrity": "sha512-/qngo2JnLswXZrWCPi3YwxBNaH/TXeXAjF4Mp/ORpNFj+qGEmIw4RuGT7nwWgVC0+0B1iFxXslWMxN8G0MOW6A==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/logo-image-css": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@utrecht/logo-image-css/-/logo-image-css-1.4.2.tgz",
-      "integrity": "sha512-TV2Svy/dkyYF6Xj422JGwueMe6CcyWZ7+RZAXNgG575nrXYxEVy5EPjfeHPQ7LmCw0QZDlA7vRLK09zbL6LLyQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/logo-image-css/-/logo-image-css-2.0.0.tgz",
+      "integrity": "sha512-6dlp72zK29IgP4KT23Mz3Fgrh8WpTRSDRja4wzErve27PJhmpq1Ho/KngMdMQiAqGkzO0IYd+DqgdOjcvKeDEA==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/map-control-button-css": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/map-control-button-css/-/map-control-button-css-3.0.1.tgz",
-      "integrity": "sha512-Y5xC2BjUnMJ6kx2X3Ebf5BTSvhPQiOPt5fGBakLFeugNsPP7+WaFv7FKtyv4FmibxwnhXPTMko6TzcypiE7zqQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/map-control-button-css/-/map-control-button-css-4.0.0.tgz",
+      "integrity": "sha512-eLHL9KJB362hi5lVZKt+n0MDsGChxW8zDVLuzrrLt4L7VtX5phqV2UKMlUj53bJ/sYAEDQ+1TXXoiMj7JYKFvg==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/map-marker-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/map-marker-css/-/map-marker-css-2.0.1.tgz",
-      "integrity": "sha512-/Qlscd5ixjeDB4ITNuvaNHyUyn/SbDuxALqOomFLZ4Q1odG1V05vC5XvlR4QsagHC5U5/CDJXKtAQ1mm3nNE0g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/map-marker-css/-/map-marker-css-3.0.0.tgz",
+      "integrity": "sha512-9XiD1pN3Fkz8ZJ9oZvcfx6KqAKIZtZFjyZGgMN3cX0HJ3y2uU6fvFUlZvffPwV9SJZZMe89GYz7hXv+SWCZgwA==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/mark-css": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@utrecht/mark-css/-/mark-css-2.0.2.tgz",
-      "integrity": "sha512-kNIazVB1e1yGEKiY6yoa20Nte7rqpuyQsoqYnudJNz5i/O7XA2MElTi1oKLLtbYeIyIetXKznDqbxRy1OLSKaw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/mark-css/-/mark-css-3.0.0.tgz",
+      "integrity": "sha512-MczVw/Et2HsfMw+iSWB49SwCc7Y8zt5ww0pFV9PkC8rS3WVqwJ3UvA/OZAW1EACzx9PYa4uInv90pGrTWwR3hw==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/multiline-data-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/multiline-data-css/-/multiline-data-css-2.0.1.tgz",
-      "integrity": "sha512-4pkVG4Loz/bS697zW2nFemQd91JlRMF3d1ss1WRbWQyXPEhY19R4GvFPhl+Tf7Oq+F2eArV1EYR+nkV9SdiCCQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/multiline-data-css/-/multiline-data-css-3.0.0.tgz",
+      "integrity": "sha512-Fav3cRA/xqUFIKZLf9uvPPBu/Uh+lWnMu4lA/gkhyxRvuPctp0+u58mBogZX9sJvycIoMIlEvPFnbSOxEaWhsA==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/nav-bar-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/nav-bar-css/-/nav-bar-css-2.0.1.tgz",
-      "integrity": "sha512-CKyHi8pe4lk1Dg2IxW8TjbFCkMflEsUHNcrKjzokjygaJS4Pls+LP0dGRt7f7q55JGXb1gjsGedEmXtLNIDRDA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/nav-bar-css/-/nav-bar-css-3.2.0.tgz",
+      "integrity": "sha512-bbKTHXZJtczqws6gVq9rZbtZtITqoz5asQMd214dlEeMRfOPP5T8Cdv+PKTb3kxJuLCN268VByJqnfzJK3LbPA==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/nav-list-css": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@utrecht/nav-list-css/-/nav-list-css-1.3.2.tgz",
-      "integrity": "sha512-1VGVeIuLgz4N9aJ0DpTHbwRwxeOQSylIdeJ3Gm8sbL2NVIx4N05heEqi3lZKMulgv35ptCROdH/LBnn0Jd41Mw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/nav-list-css/-/nav-list-css-2.0.0.tgz",
+      "integrity": "sha512-7RGKEnCLcYSPEEHph0HlfAfN7uqIeRabbu+/9UksUInsIwCpyOC3NzdZ1kHQg3H14wcadExp3AD2/NNI80p/Tw==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/number-badge-css": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/number-badge-css/-/number-badge-css-3.0.1.tgz",
-      "integrity": "sha512-t1HwU+bRlerdFicFZa4w5xyZh00ihITUb2kxU11e9Vxb2D32VU1jBOMW8qtKpuiya5mPZJjGF0uc6ZyGPAdXTw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/number-badge-css/-/number-badge-css-4.0.0.tgz",
+      "integrity": "sha512-AwG+KHr0ep/SCjCBJ1Y15QX5CPMsneT4uYOWaljCTQPBBkXlECWqvyBu4vjl5eJocMIZRMQ2IP/mRkoxh90i7w==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/number-data-css": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@utrecht/number-data-css/-/number-data-css-2.0.2.tgz",
-      "integrity": "sha512-OOTpNklOn6px7CMOUrAVrn7N2D7VTQYsL8ygFveSJxO3Aa+9VfVh+xCOgsofuAX5F7lNerydwew3fMyude0h9g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/number-data-css/-/number-data-css-3.0.0.tgz",
+      "integrity": "sha512-35xhMKootr2bo2XA0V8hXp37i+6ekmK2DLuEuoe2WOSHgRQ6MWUjZTdNJUs8fXHZ3DaVy4gY41llJ8o7y5WVaQ==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/open-forms-container-css": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@utrecht/open-forms-container-css/-/open-forms-container-css-2.0.4.tgz",
-      "integrity": "sha512-G4LD3Yc8IBwaZpLbJ3tCKn0iCYoiwRRHvEjcUWFXkVQWtEnnBoAbmeUTevSfUfHMn8b0UFTjYpw2ovfLF1qRzA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/open-forms-container-css/-/open-forms-container-css-3.0.0.tgz",
+      "integrity": "sha512-e7jFPVhyBOJqIOq6KZDyxX26Uc0iZDGmNIaVCQby8OGImGnFLR4AFOzFjvFTCzp7yfsk3l+rtgNHc8OWn/9Q6Q==",
       "license": "EUPL-1.2",
       "peer": true,
       "dependencies": {
-        "@utrecht/focus-ring-css": "3.1.0",
-        "@utrecht/textbox-css": "3.1.1"
+        "@utrecht/focus-ring-css": "4.0.0",
+        "@utrecht/textbox-css": "4.0.0"
       }
     },
+    "node_modules/@utrecht/open-forms-container-css/node_modules/@utrecht/textbox-css": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/textbox-css/-/textbox-css-4.0.0.tgz",
+      "integrity": "sha512-Y+Z3uDbIxRvnnTgB4pprGsJmDviqqIOErcsg8+ocSGO4utPDYYLe8TDceikTqKeVMkirEQEVgeAoSON679VZrQ==",
+      "license": "EUPL-1.2",
+      "peer": true
+    },
     "node_modules/@utrecht/open-forms-container-react": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@utrecht/open-forms-container-react/-/open-forms-container-react-1.0.8.tgz",
-      "integrity": "sha512-ySiAx0REf8SXXCT8mpJcGlENksgPL7z/FOjhNm0fNqcBnc8CJFEOf5lwHMyaQY9+lx7jbOc9O76S709es/9SjA==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@utrecht/open-forms-container-react/-/open-forms-container-react-1.0.9.tgz",
+      "integrity": "sha512-8SPsI4iq+l0oCEqllhnk9IOUpxAQXsE2qrei/nL6FB/tPTiiRxDCtNEEIQdd0sssvIAW2g5WHaPdRt4i92Neng==",
       "license": "EUPL-1.2",
       "peer": true,
       "dependencies": {
-        "@utrecht/open-forms-container-css": "2.0.4",
+        "@utrecht/open-forms-container-css": "3.0.0",
         "clsx": "2.1.1"
       },
       "peerDependencies": {
@@ -5571,40 +5444,41 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/ordered-list-css/-/ordered-list-css-3.0.1.tgz",
       "integrity": "sha512-FTLzofVJlkl4ypJz2QoWTwepXN+yX3Y3exL+69SpiwjAXSkRYkJ1agd0W6BZVH+JQ60u8+uApOKQpgx2Bh3ImQ==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/page-content-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/page-content-css/-/page-content-css-2.0.1.tgz",
-      "integrity": "sha512-Hgx63BEUbaGJyBQXpa97EN8ng0M9LTX3ddu9IQM+ar/rA2OGIM5oiGbwXUYhLwQp/HnhkFm/gpPGGTtQjpXC6w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/page-content-css/-/page-content-css-3.0.0.tgz",
+      "integrity": "sha512-rGLQI1XQ8yXMKDg/IkVuLrXYcaLK8qDH5/IkkjCqfAQkDoU9xDyt0iIYjr0c/44qNLqfQ2G/1LODQkY9wxIDyA==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/page-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/page-css/-/page-css-2.0.1.tgz",
-      "integrity": "sha512-5c0wLiFvnfpTn8VfjoRHmND0DSw/CYD8ydkgdZNCFkSaXOqVrhcAN3I6jTMSR+Eg9mOu1T9bswRcxIKa8NUJUA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/page-css/-/page-css-3.0.0.tgz",
+      "integrity": "sha512-hPGBzh1AXTVRVcruIxmT+pHgLynQdJ+Kk7S2YPZYeHLdSxPRmryxnyTouCa8cCDAzud4ujsjpABQdcR+VaFjyg==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/page-footer-css": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@utrecht/page-footer-css/-/page-footer-css-3.0.2.tgz",
-      "integrity": "sha512-HjO1l3fI+RUE0d3QiQHbN6z6maXvoerXiU7vpA+Qidkmlcvrm7r565cOLOTJKl191YaZb2l3b0FSoB8kGK7Xwg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@utrecht/page-footer-css/-/page-footer-css-4.0.1.tgz",
+      "integrity": "sha512-jHd+IVGik2rG/cs5KWwt15qzB9lRI5pSASNAGYUtkp5uTJ5sk/QWLxrxX19qOPzQ7Yj/uB4ctuDAunSgQT8bfg==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/page-header-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/page-header-css/-/page-header-css-2.0.1.tgz",
-      "integrity": "sha512-HxONNJxBNwqEY/qDkx3U0wAVvirc/1l04i9L4dPscjf+Le6UWkJb4pfxXVO8b8yIT+wyj2YY0k8aeBUEIJPKjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@utrecht/page-header-css/-/page-header-css-3.0.1.tgz",
+      "integrity": "sha512-kCobPBJEhEf4NaazS86cj2M/YFCekANem3UTiOt16laCqxImfMkN49bdkaoqB93vuu+3ofETlu3pdW51L9hi/g==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/pagination-css": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@utrecht/pagination-css/-/pagination-css-2.0.3.tgz",
-      "integrity": "sha512-LXXWZXEgiOacCHljs9jm9Nm2MQW7dmNtq5Ck4PENOA62oT/HVCXbiviWeT+dYLsv8Nwv+JCFYWm4CA1UGY7MOw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/pagination-css/-/pagination-css-3.0.0.tgz",
+      "integrity": "sha512-CANNiqMY2K8iW72M+5kR0DEeXJSo68yWfjl8vKJaIA7hNc/RPhknG0B1KCGtzB9lL7/gg9jSz5IkuEZtNyM0bg==",
       "license": "EUPL-1.2",
       "peer": true
     },
@@ -5612,19 +5486,20 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/paragraph-css/-/paragraph-css-3.0.1.tgz",
       "integrity": "sha512-Go+9gTJTdUuqzFiPvz7dxQohor7ExQ0Pj52wJewx3G2Acl9xbrv0mNyrLe38+v1C+wrJpy1Vg0lkvCF16HQNgw==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/pre-heading-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/pre-heading-css/-/pre-heading-css-2.0.1.tgz",
-      "integrity": "sha512-fIbGQv17jrNLgVosvcAMZOn4QR+9v3q0OgozdZ4htLkvRb92oyeHck/uhaOXtJnqWkDeWR9pf1CCwdIn9zxRCg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/pre-heading-css/-/pre-heading-css-3.0.0.tgz",
+      "integrity": "sha512-iR26Qd6HGCUlqYkf0NdA3uVcpoSMpOAb/NTKIKODzzFvS2s3iXZTKoRyhxP7E6emthOB+dKDjwltZnjJxNwU4w==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/preserve-data-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/preserve-data-css/-/preserve-data-css-2.0.1.tgz",
-      "integrity": "sha512-GDEXsGQhHTNShHVdrQlToKmglB73cXTrr3h2Zu40rF7wo/BV75qWVviH3CEh0gSOy8SLHyMgbwCBk+A0Nnp7AQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/preserve-data-css/-/preserve-data-css-3.0.0.tgz",
+      "integrity": "sha512-OQ1on2Ss9Idffw4nzFHx2q1aIopfcS9UMMUP8AtUbHcDI1MQYPcsvsWTobAXLTtoWZxdgrUz0H+DCl0ByueV9A==",
       "license": "EUPL-1.2",
       "peer": true
     },
@@ -5632,13 +5507,13 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/radio-button-css/-/radio-button-css-2.0.2.tgz",
       "integrity": "sha512-6bLq/4jGI+yCv9h+e65q1Nbbp9xb7V2St3RyLmrk8U5nYfDdNdUe6570VIDxazEFH6blk4j+rqfL7ZSTWaHQpg==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/radio-button-react": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@utrecht/radio-button-react/-/radio-button-react-1.0.12.tgz",
       "integrity": "sha512-kW48DdvYB4gPsN0uFzJ0Aw8LuwEuRycZMH33r1BPHQlq+QVi0XdVYfrYWqtyQBpktqKTfIDRAVUXGrI4HbW5gA==",
-      "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
         "@utrecht/radio-button-css": "3.0.0",
@@ -5654,20 +5529,19 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@utrecht/radio-button-css/-/radio-button-css-3.0.0.tgz",
       "integrity": "sha512-KD3EKxN6EJFoSXa7BzszOXLhGFLEXpP3sZjVsWfIIZhFbvrPvcpsJ2/jo9kKFse4+v3njbDJDZ2ZF5YJErSwNg==",
-      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/rich-text-css": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@utrecht/rich-text-css/-/rich-text-css-2.1.0.tgz",
-      "integrity": "sha512-JYr/I/wZKufKe6iji6BxQYxtNnNuhyEylOrjFH+Ju5Cz5uqD4KU5zmsjNHhYX7bMIsdUQcje4VnXNtarM4xBkw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/rich-text-css/-/rich-text-css-3.0.0.tgz",
+      "integrity": "sha512-lrytwDqDTPyKiOhoYqLe6hRsI8I/doIN48Hrliei6PxPx7WCh4McUPVvewQgZkS7dxT+dLyDpqMlP4CIQynByA==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/search-bar-css": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@utrecht/search-bar-css/-/search-bar-css-3.0.2.tgz",
-      "integrity": "sha512-R7hORuwr2u/zVLybHxO72ZpPx0MtTTqoTBBrpLsgLNJGUsbS6s61e83RXGmE+Dr8U9Mokj1K2DTjnNxsYtSxzA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/search-bar-css/-/search-bar-css-4.0.0.tgz",
+      "integrity": "sha512-2mseIAkReJC/HlbfamD2eTbjBCo05s05DCABXG1GWGWBrVQF2uIY4UoGVQP7q2i26MGsd19VrX031VxHAMn5EA==",
       "license": "EUPL-1.2",
       "peer": true
     },
@@ -5675,33 +5549,34 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/select-css/-/select-css-2.0.2.tgz",
       "integrity": "sha512-00VyDxGCMTqhC+Y98nwrc6zXXezB7hwsRlI78X1Hkl5lywESlT4frBWaCs6dw4e/lgYGskDx7KCpChwMtgYxxg==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/separator-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/separator-css/-/separator-css-2.0.1.tgz",
-      "integrity": "sha512-TpD/3w8N14XJD3hRKqpgftLFlmNveheNN9KUjBD3MEJF96i9e7S/4+YIasWicCHxrsQpicc28ERJLlGCRow+UA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/separator-css/-/separator-css-3.0.0.tgz",
+      "integrity": "sha512-NmqHbJlPHeIomXjup1QRonrn73DeStRPxRwsHGM1mrMlTtDy3r/+FtWgiGr4UJti9V/SM+/fkKYbM89u88V1yA==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/skip-link-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/skip-link-css/-/skip-link-css-2.0.1.tgz",
-      "integrity": "sha512-cH2UHLrcSKJHWid1i+VRzsrZMxLAHjmXiU332H5PJDLf5ImjjF0YVaw41+/d0yfWVH5UIEJj+el7naFzyA9/1w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/skip-link-css/-/skip-link-css-3.0.0.tgz",
+      "integrity": "sha512-dWDQrgDPlsLbR14xnboF5cJRHVhXyHWxfgyxkCi5OWJ/VBeR8Qsjs0WyR3ySC8rvrQeG4uunB5tGUgUBlcQf6w==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/spotlight-section-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/spotlight-section-css/-/spotlight-section-css-2.0.1.tgz",
-      "integrity": "sha512-BzymCAj6Im0OAzpHs3iSqX+5lNIVD9EbElC9RCeFASTlp5Yc9iO2hj9CCeQD6yPuVuZBD84vND6p4JeMgeLPJg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@utrecht/spotlight-section-css/-/spotlight-section-css-3.0.1.tgz",
+      "integrity": "sha512-BjfbtEwaAfILQSdabm+pMG00WdAm17pz3cuvcDBt4U9R/ZZSEB2LXGeWfW7yXmD6NmpGn/+UFuTE7a2RRJ4iEw==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/status-badge-css": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@utrecht/status-badge-css/-/status-badge-css-1.0.0.tgz",
-      "integrity": "sha512-rkbK0l+DdXMApss6WJWKPzRk0/5k3q0Q+UB0Uzc0YdhZJG7iUS/RzmygDDcv346HfI5Ki8nZT3HG7Wjw2rIWMQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/status-badge-css/-/status-badge-css-2.0.0.tgz",
+      "integrity": "sha512-Kp6mgH/O71Dy1ixGpOvmSZgGTtF8WdV1FLLO+ED+BHOP9hkpTr4kkXbw/54uHnNnMDxlEDWCtcjE+/9vPwow2Q==",
       "license": "EUPL-1.2",
       "peer": true
     },
@@ -5709,18 +5584,20 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/subscript-css/-/subscript-css-2.0.1.tgz",
       "integrity": "sha512-Wg/lQA+vzQXVTEG88nMGzY2wi0WAYv++mBqd2P1mn6O0bgd4L6YxMppuOJs0J+RpMwHj65pUAbn/k6Ykh5i+iw==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/superscript-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/superscript-css/-/superscript-css-2.0.1.tgz",
       "integrity": "sha512-9drVAc0r2BA+634AT2tsmYAQ415lh5Y0mSEfZVQELQ10PR6acxLQkPwDVpjVUy9LRHPhWHyA+JVesjHPDrv8bQ==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/surface-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/surface-css/-/surface-css-2.0.1.tgz",
-      "integrity": "sha512-CVFH5D41ePrS7Lqw7Tlxl4/Wy06yiP7pEjp+ZJkuPuaXLrmHO+S0L78t01xNzoVm8ASUyFjz3VTT3NdvZFDXyw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/surface-css/-/surface-css-3.0.0.tgz",
+      "integrity": "sha512-gPB4rmhAXOWU2Q02Vt8gddu+FSXV+5Bg1zPfvqCUiMxdAFzLumU1MCf35OIJNL1SICTU1rrJMFj1qcpChfVZ1A==",
       "license": "EUPL-1.2",
       "peer": true
     },
@@ -5728,12 +5605,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@utrecht/table-css/-/table-css-2.0.3.tgz",
       "integrity": "sha512-tAcVA9pVAArKVGLcwkWPB4SybSGo8I4145to6zAEgikJalqDRB/cPQ9TpmF911haEbn1a8UwMCXpMvzFZwRUZA==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/table-of-contents-css": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@utrecht/table-of-contents-css/-/table-of-contents-css-1.0.2.tgz",
-      "integrity": "sha512-xMZM/MuwK+c0bLLrqdWq5HfJy2OmLM9C2y8seLOjbxO9qVoYKNbFKUg/WsuR0J0VCzLRQz/w7UzAMj0MSqckrA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/table-of-contents-css/-/table-of-contents-css-2.0.0.tgz",
+      "integrity": "sha512-h55HS+r89tkql+s/0ZD9FV7wvp6XbEppGO3lLU7yDdl1V27XGjT5I0nFQ4vFKHJMFedgTMkWEBOchJff+7cxHQ==",
       "license": "EUPL-1.2",
       "peer": true
     },
@@ -5741,19 +5619,20 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/textarea-css/-/textarea-css-3.0.2.tgz",
       "integrity": "sha512-i1sA7Mqua7va7zzhCeP/npg2/yoKtrEs93QADqIPx5Opj1rbJ9c+5EGagZXA921GyzFhISAIo1sKvn6sc9TiBg==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/textbox-css": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@utrecht/textbox-css/-/textbox-css-3.1.1.tgz",
       "integrity": "sha512-jWahVT2rVrPAdSCfErDXyDRBFqdWJo8hSueYS33EeX/EcU/ljRlp+Rwp95DHYQkxCfQio86uUp2cgacIMgfvmQ==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/textbox-react": {
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/@utrecht/textbox-react/-/textbox-react-1.0.15.tgz",
       "integrity": "sha512-uuCIvsHLJP6zxyY7s207M1j2RvYNwQwCxZT3JB+6f/dWvxLx+5xo0Z0Lk4lUw7agy5Mo41pAQZYFeBkEBvXx1g==",
-      "dev": true,
       "license": "EUPL-1.2",
       "dependencies": {
         "@utrecht/textbox-css": "4.0.0",
@@ -5769,20 +5648,19 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@utrecht/textbox-css/-/textbox-css-4.0.0.tgz",
       "integrity": "sha512-Y+Z3uDbIxRvnnTgB4pprGsJmDviqqIOErcsg8+ocSGO4utPDYYLe8TDceikTqKeVMkirEQEVgeAoSON679VZrQ==",
-      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/top-task-link-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@utrecht/top-task-link-css/-/top-task-link-css-2.0.1.tgz",
-      "integrity": "sha512-SYO6xr4Q1ipaw1xXT1UZMCnjm0MwtKzdgE9NX7ahfBv4wWKiUnLF8yoykYgFTHQIGhIiiV6VW6L6gazFLx3f+w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/top-task-link-css/-/top-task-link-css-3.0.0.tgz",
+      "integrity": "sha512-xjvhphaH6JFJOrubZcpkW+YhzdJIsOWBSMip4zsy7qMjo9pxLuoJyK8++N4GW4AJYfvON0tk42ZAqD1ACmHetA==",
       "license": "EUPL-1.2",
       "peer": true
     },
     "node_modules/@utrecht/top-task-nav-css": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@utrecht/top-task-nav-css/-/top-task-nav-css-1.3.2.tgz",
-      "integrity": "sha512-jdSjHfNcnyokuwwHB2cEYMRRMckLP90hdMiM8omUl2aUf1zL0gqBpzca2uKJPgrzv+PaL1R5XuJGcP6NC8vJkQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@utrecht/top-task-nav-css/-/top-task-nav-css-2.0.0.tgz",
+      "integrity": "sha512-kuvPdZRkk9bemZXIm52Kd39wyrWQjETUZgUKpQBFn2qTsVXej2mcwdAkEjbtxYSUrzcPeeH6yBkPSHsWa7AvLw==",
       "license": "EUPL-1.2",
       "peer": true
     },
@@ -5790,20 +5668,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@utrecht/unordered-list-css/-/unordered-list-css-2.0.1.tgz",
       "integrity": "sha512-YZXOOkX9wZ4niq1nkcb+rLse1EcvVjRSyaHP5H2kYbWxXNH1oL41WLzg+sfh/v7swm47TYzXyxCKe7s66DWPbw==",
+      "dev": true,
       "license": "EUPL-1.2"
     },
     "node_modules/@utrecht/url-data-css": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@utrecht/url-data-css/-/url-data-css-2.0.2.tgz",
       "integrity": "sha512-YcOQw74oneMbz5LQ6mGKy5UNSBYk3MJ8p5HXupDRksDvbA4hhD4TkiUF3q6jMF8s2R1+TtXGsPSLlJ6cOcAowg==",
+      "dev": true,
       "license": "EUPL-1.2"
-    },
-    "node_modules/@utrecht/vega-visualization-css": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@utrecht/vega-visualization-css/-/vega-visualization-css-1.4.2.tgz",
-      "integrity": "sha512-JTTx1DsKIeYZz95+H34HGfocKjDpbVOsFdPK1f/b3U3C5ivdC75fTkzU1+tVp6ijPwKnWPNr6eiIXTY9tHj5Kg==",
-      "license": "EUPL-1.2",
-      "peer": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@utrecht/button-react": "^3.0.2",
     "@utrecht/calendar-react": "^1.1.2",
     "@utrecht/checkbox-react": "^1.0.13",
-    "@utrecht/component-library-react": "^13.1.0",
+    "@utrecht/component-library-react": "^14.0.0 || ^13.1.0",
     "@utrecht/fieldset-react": "^1.0.12",
     "@utrecht/form-field-description-react": "^1.0.11",
     "@utrecht/form-field-react": "^1.0.12",


### PR DESCRIPTION
It's a major version because the vega-visualization package was removed, as it was the main cause for peer dependency issues. We don't use that package/component, so it does not affect us, and upgrading will make our dependency resolution chain simpler.