### PR TITLE
Bandaid fix for odd conditional.eq comparison with file components

### DIFF
--- a/src/registry/file/conditional.spec.ts
+++ b/src/registry/file/conditional.spec.ts
@@ -1,0 +1,47 @@
+import type {FileComponentSchema, JSONValue} from '@open-formulieren/types';
+import type {FileUploadData} from '@open-formulieren/types/dist/components/file';
+import {expect, test} from 'vitest';
+
+import testConditional from './conditional';
+import {buildFile} from './test-utils';
+
+test.each([
+  // file components are weird and the formio-builder currently emits strings as
+  // comparison value
+  ['', [] satisfies FileUploadData[], true],
+  [
+    '',
+    [
+      buildFile({name: 'foo.png', size: 123, type: 'image/png', state: undefined}),
+    ] satisfies FileUploadData[],
+    false,
+  ],
+  ['garbage data', [] satisfies FileUploadData[], false],
+  [
+    'garbage data',
+    [
+      buildFile({name: 'foo.png', size: 123, type: 'image/png', state: undefined}),
+    ] satisfies FileUploadData[],
+    false,
+  ],
+])(
+  'File testConditional compares against empty array',
+  (compareValue: string, valueToTest: FileUploadData[], expected: boolean) => {
+    const component: FileComponentSchema = {
+      type: 'file',
+      key: 'file',
+      id: 'file',
+      label: 'File',
+      file: {
+        name: '',
+        type: ['*'],
+        allowedTypesLabels: ['anything'],
+      },
+      filePattern: '*',
+    };
+
+    const result = testConditional(component, compareValue, valueToTest as unknown as JSONValue[]);
+
+    expect(result).toBe(expected);
+  }
+);

--- a/src/registry/file/conditional.ts
+++ b/src/registry/file/conditional.ts
@@ -1,0 +1,18 @@
+import type {FileComponentSchema} from '@open-formulieren/types';
+
+import type {TestConditional} from '@/registry/types';
+
+// should normally be FileUploadData[], but due to historical reasons/mistakes strings
+// are actually returned
+const testConditional: TestConditional<FileComponentSchema, string> = (
+  _: FileComponentSchema,
+  compareValue,
+  valueToTest
+): boolean => {
+  if (!Array.isArray(valueToTest)) return false;
+  // we normalize empty strings to the semantic meaning of 'are there no file uploads?'
+  // which requires the value array to be empty.
+  return compareValue === '' && valueToTest.length === 0;
+};
+
+export default testConditional;

--- a/src/registry/file/index.tsx
+++ b/src/registry/file/index.tsx
@@ -6,6 +6,7 @@ import type {RegistryEntry} from '@/registry/types';
 import type {FormioFileProps} from './File';
 import './File.scss';
 import ValueDisplay from './ValueDisplay';
+import testConditional from './conditional';
 import isEmpty from './empty';
 import getInitialValues from './initialValues';
 import getValidationSchema from './validationSchema';
@@ -29,6 +30,7 @@ const FileComponent: RegistryEntry<FileComponentSchema> = {
   valueDisplay: ValueDisplay,
   getInitialValues,
   getValidationSchema,
+  testConditional,
   isEmpty,
 };
 


### PR DESCRIPTION
Closes open-formulieren/open-forms#6181

The builder is misconfigured and allows string values to be provided as comparison value, and the proper fix for it takes a lot more work so we apply a workaround to match the legacy renderer behaviour.