### PR TITLE
Fix datetime validation executing too early

### DIFF
--- a/src/components/forms/DateTimeField/DateTimeField.tsx
+++ b/src/components/forms/DateTimeField/DateTimeField.tsx
@@ -156,7 +156,7 @@ const DateTimeField: React.FC<DateTimeFieldProps> = ({
     [currentDateTime]
   );
 
-  const onPartChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const onPartChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     // we must cast here since we can't pass the valid input names as a generic.
     const partName = event.target.name as DateTimePart;
     const value = event.target.value;
@@ -173,8 +173,8 @@ const DateTimeField: React.FC<DateTimeFieldProps> = ({
       // object. This is possible, because the date picker and time input return a date and time
       // ISO-8601 string, respectively.
       const date_ = parseDateTime(`${newDateParts.date}T${newDateParts.time}:00`)!;
-      setValue(formatISO(date_!));
-      setTouched(true);
+      await setValue(formatISO(date_!));
+      await setTouched(true);
       validateField(name);
     }
   };

--- a/src/registry/datetime/index.stories.tsx
+++ b/src/registry/datetime/index.stories.tsx
@@ -551,7 +551,7 @@ export const ValidateSelectedDatetime: ValidationStory = {
   },
 };
 
-export const ValidateSelectedWithInitialErrorDatePicker: ValidationStory = {
+export const ValidateSelectedDatetimeWithInitialError: ValidationStory = {
   ...BaseValidationStory,
   decorators: [withMockDate],
   args: {


### PR DESCRIPTION
Closes open-formulieren/open-forms#6313

See also this [comment](https://github.com/open-formulieren/formio-renderer/pull/315#discussion_r3136840105): 
> I have added all the tests with a big disclaimer that is it really difficult to reproduce these issues in the tests. Some of them already succeeded in the current configuration, whereas performing the exact same steps manually gives a different result 🙃