### PR TITLE
Allow hiding the addressNL component label

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
-        "@open-formulieren/types": "^1.0.1",
+        "@open-formulieren/types": "^1.3.0",
         "clsx": "^2.1.0",
         "dompurify": "^3.2.6",
         "formik": "^2.4.5",
@@ -2234,9 +2234,9 @@
       }
     },
     "node_modules/@open-formulieren/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-Twb1CwWzsdpD8v2u+1gWpnymyfET1jZemXcwh2hLHw64d8GHPfno2UtHa7PMu/3dHH07/bNKVh7mYHEQ0PEtDA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-1.3.0.tgz",
+      "integrity": "sha512-fSzo0glfvIJy0e23tjNst/eiPm+TgY/mD1jCsS9QpggdOQQe2MdEaj5h94yJTEZcgtlXyv9sOjEOVoKT4XKtmg==",
       "license": "EUPL-1.2"
     },
     "node_modules/@parcel/watcher": {

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.29.2",
-    "@open-formulieren/types": "^1.0.1",
+    "@open-formulieren/types": "^1.3.0",
     "clsx": "^2.1.0",
     "dompurify": "^3.2.6",
     "formik": "^2.4.5",

--- a/src/components/forms/Fieldset.tsx
+++ b/src/components/forms/Fieldset.tsx
@@ -8,6 +8,7 @@ export interface FieldsetProps {
   hasTooltip?: boolean;
   isInvalid?: boolean;
   className?: string;
+  headerHidden?: boolean;
 }
 
 /**
@@ -18,6 +19,7 @@ export interface FieldsetProps {
  */
 const Fieldset: React.FC<FieldsetProps & React.ComponentProps<'fieldset'>> = ({
   header,
+  headerHidden,
   hasTooltip,
   isInvalid,
   className,
@@ -29,7 +31,7 @@ const Fieldset: React.FC<FieldsetProps & React.ComponentProps<'fieldset'>> = ({
       'openforms-fieldset',
       {
         'openforms-fieldset--invalid': isInvalid,
-        'openforms-fieldset--no-header': !header,
+        'openforms-fieldset--no-header': !header || headerHidden,
       },
       className
     )}
@@ -39,6 +41,7 @@ const Fieldset: React.FC<FieldsetProps & React.ComponentProps<'fieldset'>> = ({
       <legend
         className={clsx('openforms-fieldset__legend', {
           'openforms-fieldset__legend--tooltip': hasTooltip,
+          'sr-only': headerHidden,
         })}
       >
         {header}

--- a/src/registry/addressNL/index.stories.tsx
+++ b/src/registry/addressNL/index.stories.tsx
@@ -97,6 +97,48 @@ export const MinimalConfigurationDoubleColumn: Story = {
   },
 };
 
+export const WithoutLabel: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'addressNL',
+      key: 'my.address',
+      label: 'Your address',
+      deriveAddress: false,
+      layout: 'singleColumn',
+      hideLabel: true,
+      validate: {
+        required: true,
+      },
+    } satisfies AddressNLComponentSchema,
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          address: {
+            postcode: '',
+            houseNumber: '',
+            houseLetter: '',
+            houseNumberAddition: '',
+            // optional properties depending on the features used
+            city: undefined,
+            streetName: undefined,
+            secretStreetCity: undefined,
+            autoPopulated: undefined,
+          } satisfies AddressData,
+        },
+      },
+    },
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    const fieldset = canvas.getByRole('group');
+    expect(fieldset).toBeVisible();
+    expect(fieldset).toHaveAccessibleName('Your address');
+  },
+};
+
 export const WithDescriptionAndTooltip: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/addressNL/index.tsx
+++ b/src/registry/addressNL/index.tsx
@@ -35,6 +35,7 @@ export const FormioAddressNL: React.FC<FormioAddressNLProps> = ({
   componentDefinition: {
     key,
     label,
+    hideLabel,
     tooltip,
     description,
     validate,
@@ -63,7 +64,7 @@ export const FormioAddressNL: React.FC<FormioAddressNLProps> = ({
 
   const invalid = touched && !!addressError;
   const errorMessageId = invalid ? `${id}-error-message` : undefined;
-  const descriptionid = `${id}-description`;
+  const descriptionid = description ? `${id}-description` : '';
 
   // An address as a whole is or is not required.
   const isRequired = validate?.required;
@@ -84,6 +85,7 @@ export const FormioAddressNL: React.FC<FormioAddressNLProps> = ({
           {tooltip && <Tooltip>{tooltip}</Tooltip>}
         </>
       }
+      headerHidden={hideLabel}
       isInvalid={invalid}
       hasTooltip={!!tooltip}
       className={clsx('openforms-addressnl', {

--- a/src/registry/fieldset/index.stories.ts
+++ b/src/registry/fieldset/index.stories.ts
@@ -79,6 +79,41 @@ export const WithTooltip: Story = {
   },
 };
 
+export const WithoutLabel: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'fieldset',
+      key: 'fieldset',
+      label: 'Fieldset label',
+      hideHeader: true,
+      components: [
+        {
+          id: 'component2',
+          type: 'textfield',
+          key: 'my.textfield',
+          label: 'A simple textfield',
+        },
+      ],
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          textfield: '',
+        },
+      },
+    },
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    const fieldset = canvas.getByRole('group');
+    expect(fieldset).toBeVisible();
+    expect(fieldset).toHaveAccessibleName('Fieldset label');
+  },
+};
+
 interface ValidationStoryArgs {
   nestedComponents: AnyComponentSchema[];
   onSubmit: FormioFormProps['onSubmit'];

--- a/src/registry/fieldset/index.tsx
+++ b/src/registry/fieldset/index.tsx
@@ -22,13 +22,12 @@ export const FormioFieldset: React.FC<FieldsetProps> = ({
   return (
     <Fieldset
       header={
-        hideHeader ? undefined : (
-          <>
-            {label}
-            {tooltip && <Tooltip>{tooltip}</Tooltip>}
-          </>
-        )
+        <>
+          {label}
+          {tooltip && <Tooltip>{tooltip}</Tooltip>}
+        </>
       }
+      headerHidden={hideHeader}
       hasTooltip={!!tooltip}
     >
       <FormFieldContainer>


### PR DESCRIPTION
Closes #167

This also improves the accessibility of the fieldset component with the similar option (`hideHeader`), as both use the underlying fieldset component.