### PR TITLE
Fix interaction bugs in `addressNL` component

### DIFF
--- a/i18n/compiled/en.json
+++ b/i18n/compiled/en.json
@@ -1869,6 +1869,12 @@
       "value": "Click first point to finish shape"
     }
   ],
+  "w4culW": [
+    {
+      "type": 0,
+      "value": "The entered postcode and number don't result into a known address."
+    }
+  ],
   "wiPGoP": [
     {
       "type": 0,

--- a/i18n/compiled/nl.json
+++ b/i18n/compiled/nl.json
@@ -1811,6 +1811,12 @@
       "value": "Klik op het eerste punt, om de veelhoek te voltooien"
     }
   ],
+  "w4culW": [
+    {
+      "type": 0,
+      "value": "The entered postcode and number don't result into a known address."
+    }
+  ],
   "wiPGoP": [
     {
       "type": 0,

--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -894,6 +894,11 @@
     "description": "Draw handler polygon tooltip end.",
     "originalDefault": "Click first point to finish shape"
   },
+  "w4culW": {
+    "defaultMessage": "The entered postcode and number don't result into a known address.",
+    "description": "Validation error for empty address derivation result.",
+    "originalDefault": "The entered postcode and number don't result into a known address."
+  },
   "wiPGoP": {
     "defaultMessage": "Add partner details",
     "description": "Partners component: 'add partner' button label",

--- a/i18n/messages/nl.json
+++ b/i18n/messages/nl.json
@@ -901,6 +901,11 @@
     "description": "Draw handler polygon tooltip end.",
     "originalDefault": "Click first point to finish shape"
   },
+  "w4culW": {
+    "defaultMessage": "The entered postcode and number don't result into a known address.",
+    "description": "Validation error for empty address derivation result.",
+    "originalDefault": "The entered postcode and number don't result into a known address."
+  },
   "wiPGoP": {
     "defaultMessage": "Partner toevoegen",
     "description": "Partners component: 'add partner' button label",

--- a/src/components/forms/TextField/TextField.tsx
+++ b/src/components/forms/TextField/TextField.tsx
@@ -64,6 +64,12 @@ export interface TextFieldProps {
    */
   isMultiValue?: boolean;
   /**
+   * Optional name for the validate hook invoked when blurring the field. Useful for
+   * composite fields where editing one aspect should trigger validation of the whole
+   * composite.
+   */
+  nameForValidate?: string;
+  /**
    * Any additional content, positioned between the text field and the description (if any).
    */
   children?: React.ReactNode;
@@ -86,6 +92,7 @@ const TextField: React.FC<TextFieldProps & TextboxProps> = ({
   maxLength,
   showCharCount = false,
   isMultiValue = false,
+  nameForValidate = undefined,
   children,
   ...extraProps
 }) => {
@@ -120,7 +127,7 @@ const TextField: React.FC<TextFieldProps & TextboxProps> = ({
           {...props}
           onBlur={async e => {
             props.onBlur(e);
-            await validateField(name);
+            await validateField(nameForValidate ?? name);
           }}
           className="utrecht-textbox--openforms"
           id={id}

--- a/src/registry/addressNL/deriveAddress.ts
+++ b/src/registry/addressNL/deriveAddress.ts
@@ -76,25 +76,17 @@ export const useDeriveAddress = (key: string, enabled: boolean): UseDeriveAddres
       setFieldValue(`${key}.city`, result.city);
       setFieldValue(`${key}.secretStreetCity`, result.secretStreetCity);
       setFieldValue(`${key}.autoPopulated`, true);
-      // ensure that validation errors can be displayed
-      setFieldTouched(`${key}.streetName`);
-      setFieldTouched(`${key}.city`);
     }
-  }, [
-    key,
-    setFieldValue,
-    setFieldTouched,
-    doAddressAutoComplete,
-    skipAutoFill,
-    postcode,
-    houseNumber,
-  ]);
+  }, [key, setFieldValue, doAddressAutoComplete, skipAutoFill, postcode, houseNumber]);
 
   // run client-side validation on the whole address when changed by the autofill hook
   useEffect(() => {
     if (!autoPopulated) return;
     validateField(key);
-  }, [key, validateField, autoPopulated, streetName, city]);
+    // ensure that validation errors can be displayed
+    setFieldTouched(`${key}.streetName`);
+    setFieldTouched(`${key}.city`);
+  }, [key, validateField, setFieldTouched, autoPopulated, streetName, city]);
 
   return {enableManualEntry};
 };

--- a/src/registry/addressNL/deriveAddress.ts
+++ b/src/registry/addressNL/deriveAddress.ts
@@ -90,12 +90,10 @@ export const useDeriveAddress = (key: string, enabled: boolean): UseDeriveAddres
     houseNumber,
   ]);
 
-  // run client-side validation on the city/street name fields when changed by the
-  // autofill hook
+  // run client-side validation on the whole address when changed by the autofill hook
   useEffect(() => {
     if (!autoPopulated) return;
-    validateField(`${key}.streetName`);
-    validateField(`${key}.city`);
+    validateField(key);
   }, [key, validateField, autoPopulated, streetName, city]);
 
   return {enableManualEntry};

--- a/src/registry/addressNL/deriveAddress.ts
+++ b/src/registry/addressNL/deriveAddress.ts
@@ -20,7 +20,8 @@ const testValidInputs = (postcode: string, houseNumber: string): boolean => {
 };
 
 export const useDeriveAddress = (key: string, enabled: boolean): UseDeriveAddress => {
-  const {getFieldProps, setFieldValue} = useFormikContext<FormValues>();
+  const {getFieldProps, setFieldValue, setFieldTouched, validateField} =
+    useFormikContext<FormValues>();
   key = useFieldConfig(key);
   const {value} = getFieldProps<AddressData | undefined>(key);
   const formSettings = useFormSettings();
@@ -36,7 +37,7 @@ export const useDeriveAddress = (key: string, enabled: boolean): UseDeriveAddres
 
   // debounce to avoid rapidly firing updates when the user is typing
   const addressData = useDebounce(value, 300) ?? EMPTY_ADDRESS;
-  const {postcode, houseNumber} = addressData;
+  const {postcode, houseNumber, streetName, city, autoPopulated} = addressData;
 
   // if postcode/house number change, check if we need to clear the derived inputs
   useEffect(() => {
@@ -75,8 +76,27 @@ export const useDeriveAddress = (key: string, enabled: boolean): UseDeriveAddres
       setFieldValue(`${key}.city`, result.city);
       setFieldValue(`${key}.secretStreetCity`, result.secretStreetCity);
       setFieldValue(`${key}.autoPopulated`, true);
+      // ensure that validation errors can be displayed
+      setFieldTouched(`${key}.streetName`);
+      setFieldTouched(`${key}.city`);
     }
-  }, [key, setFieldValue, doAddressAutoComplete, skipAutoFill, postcode, houseNumber]);
+  }, [
+    key,
+    setFieldValue,
+    setFieldTouched,
+    doAddressAutoComplete,
+    skipAutoFill,
+    postcode,
+    houseNumber,
+  ]);
+
+  // run client-side validation on the city/street name fields when changed by the
+  // autofill hook
+  useEffect(() => {
+    if (!autoPopulated) return;
+    validateField(`${key}.streetName`);
+    validateField(`${key}.city`);
+  }, [key, validateField, autoPopulated, streetName, city]);
 
   return {enableManualEntry};
 };

--- a/src/registry/addressNL/index.spec.tsx
+++ b/src/registry/addressNL/index.spec.tsx
@@ -55,3 +55,36 @@ test('addressNL can be conditionally displayed', async () => {
   await expect.element(screen.getByLabelText('Postcode')).toBeVisible();
   await expect.element(screen.getByLabelText('House number', {exact: true})).toBeVisible();
 });
+
+test('addressNL displays custom validation errors', async () => {
+  const components = [
+    {
+      id: 'addressNL',
+      type: 'addressNL',
+      key: 'addressNL',
+      label: 'Address',
+      layout: 'singleColumn',
+      deriveAddress: false,
+      openForms: {
+        components: {
+          postcode: {
+            validate: {
+              pattern: '1043 ?GR',
+            },
+            // must be set by the backend!
+            errors: {
+              pattern: 'Custom pattern error',
+            },
+          },
+        },
+      },
+    } satisfies AddressNLComponentSchema,
+  ];
+
+  const screen = await render(<Form components={components} onSubmit={vi.fn()} />);
+
+  await expect.element(screen.getByRole('group', {name: 'Address'})).toBeVisible();
+  await screen.getByRole('textbox', {name: 'Postcode'}).fill('1234 AB');
+  await screen.getByRole('textbox', {name: 'House letter'}).click();
+  await expect.element(screen.getByText('Custom pattern error')).toBeVisible();
+});

--- a/src/registry/addressNL/subFields.tsx
+++ b/src/registry/addressNL/subFields.tsx
@@ -37,6 +37,7 @@ interface PostCodeFieldProps {
 export const PostCodeField: React.FC<PostCodeFieldProps> = ({namePrefix, isRequired}) => (
   <TextField
     name={`${namePrefix}.postcode`}
+    nameForValidate={namePrefix.split('.')[0]}
     label={<FormattedMessage {...FIELD_LABELS.postcode} />}
     placeholder="1234 AB"
     isRequired={isRequired}
@@ -51,6 +52,7 @@ interface HouseNumberFieldProps {
 export const HouseNumberField: React.FC<HouseNumberFieldProps> = ({namePrefix, isRequired}) => (
   <TextField
     name={`${namePrefix}.houseNumber`}
+    nameForValidate={namePrefix.split('.')[0]}
     label={<FormattedMessage {...FIELD_LABELS.houseNumber} />}
     inputMode="numeric"
     placeholder="123"
@@ -65,6 +67,7 @@ interface HouseLetterProps {
 export const HouseLetter: React.FC<HouseLetterProps> = ({namePrefix}) => (
   <TextField
     name={`${namePrefix}.houseLetter`}
+    nameForValidate={namePrefix.split('.')[0]}
     label={<FormattedMessage {...FIELD_LABELS.houseLetter} />}
   />
 );
@@ -76,6 +79,7 @@ interface HouseNumberAdditionProps {
 export const HouseNumberAddition: React.FC<HouseNumberAdditionProps> = ({namePrefix}) => (
   <TextField
     name={`${namePrefix}.houseNumberAddition`}
+    nameForValidate={namePrefix.split('.')[0]}
     label={<FormattedMessage {...FIELD_LABELS.houseNumberAddition} />}
   />
 );
@@ -89,6 +93,7 @@ interface StreetNameProps {
 export const StreetName: React.FC<StreetNameProps> = ({namePrefix, isRequired, isReadOnly}) => (
   <TextField
     name={`${namePrefix}.streetName`}
+    nameForValidate={namePrefix.split('.')[0]}
     label={<FormattedMessage {...FIELD_LABELS.streetName} />}
     isRequired={isRequired}
     isReadOnly={isReadOnly}
@@ -104,6 +109,7 @@ interface CityProps {
 export const City: React.FC<CityProps> = ({namePrefix, isRequired, isReadOnly}) => (
   <TextField
     name={`${namePrefix}.city`}
+    nameForValidate={namePrefix.split('.')[0]}
     label={<FormattedMessage {...FIELD_LABELS.city} />}
     isRequired={isRequired}
     isReadOnly={isReadOnly}

--- a/src/registry/addressNL/validation.stories.ts
+++ b/src/registry/addressNL/validation.stories.ts
@@ -265,3 +265,47 @@ export const AutofillDoesNotResolve: Story = {
     ).toBeVisible();
   },
 };
+
+export const RectifyInitialError: Story = {
+  ...BaseValidationStory,
+  args: {
+    onSubmit: fn(),
+    componentDefinition: {
+      id: 'component1',
+      type: 'addressNL',
+      key: 'my.address',
+      label: 'Your address',
+      deriveAddress: false,
+      layout: 'doubleColumn',
+    } satisfies AddressNLComponentSchema,
+  },
+
+  play: async ({canvasElement, step, args}) => {
+    const canvas = within(canvasElement);
+    const submitButton = canvas.getByRole('button', {name: 'Submit'});
+
+    await step('Make initial error', async () => {
+      const postcodeField = canvas.getByLabelText('Postcode');
+      await userEvent.type(postcodeField, '9999 ZZ');
+      const houseNumberField = canvas.getByLabelText('House number');
+      // focus field, but leave it empty and shift focus elsewhere, to make sure the error is displayed
+      await userEvent.click(houseNumberField);
+      await userEvent.click(canvas.getByLabelText('House letter'));
+      expect(
+        await canvas.findByText('The required field House number must be filled in.')
+      ).toBeVisible();
+    });
+
+    await step('Clear original postcode field', async () => {
+      const postcodeField = canvas.getByLabelText('Postcode');
+      await userEvent.clear(postcodeField);
+      await userEvent.keyboard('{Tab}');
+    });
+
+    await step('Submit', async () => {
+      await waitFor(() => expect(submitButton).toHaveAttribute('data-is-valid', 'true'));
+      await userEvent.click(submitButton);
+      await waitFor(() => expect(args.onSubmit).toHaveBeenCalled());
+    });
+  },
+};

--- a/src/registry/addressNL/validation.stories.ts
+++ b/src/registry/addressNL/validation.stories.ts
@@ -218,8 +218,7 @@ export const CustomPatternsAndErrorMessages: Story = {
       expect(canvas.getByLabelText('Street name')).toHaveDisplayValue('Laanlaan');
       expect(canvas.getByLabelText('City')).toHaveDisplayValue('Betondam');
     });
-
-    await userEvent.click(canvas.getByRole('button', {name: 'Submit'}));
+    // error must be displayed *before* a submit event takes place
     expect(await canvas.findByText('Postcode area must be in 31XX or 32XX.')).toBeVisible();
     expect(await canvas.findByText('The location must be Utreg.')).toBeVisible();
   },

--- a/src/registry/addressNL/validation.stories.ts
+++ b/src/registry/addressNL/validation.stories.ts
@@ -223,3 +223,45 @@ export const CustomPatternsAndErrorMessages: Story = {
     expect(await canvas.findByText('The location must be Utreg.')).toBeVisible();
   },
 };
+
+export const AutofillDoesNotResolve: Story = {
+  ...BaseValidationStory,
+  args: {
+    onSubmit: fn(),
+    componentDefinition: {
+      id: 'component1',
+      type: 'addressNL',
+      key: 'my.address',
+      label: 'Your address',
+      deriveAddress: true,
+      layout: 'doubleColumn',
+    } satisfies AddressNLComponentSchema,
+  },
+  parameters: {
+    formSettings: {
+      componentParameters: {
+        addressNL: {
+          // simulates the response of a lookup without results
+          addressAutoComplete: async () => ({
+            streetName: '',
+            city: '',
+            secretStreetCity: '',
+          }),
+        },
+      } satisfies FormSettings['componentParameters'],
+    },
+  },
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    const postcodeField = canvas.getByLabelText('Postcode');
+    await userEvent.type(postcodeField, '9999 ZZ');
+    const houseNumberField = canvas.getByLabelText('House number');
+    await userEvent.type(houseNumberField, '99999');
+
+    expect(
+      await canvas.findByText("The entered postcode and number don't result into a known address.")
+    ).toBeVisible();
+  },
+};

--- a/src/registry/addressNL/validationSchema.spec.ts
+++ b/src/registry/addressNL/validationSchema.spec.ts
@@ -1,5 +1,6 @@
 import type {AddressNLComponentSchema} from '@open-formulieren/types';
 import type {AddressData} from '@open-formulieren/types/dist/components/addressNL';
+import {isEqual} from 'lodash';
 import {createIntl} from 'react-intl';
 import {describe, expect, test} from 'vitest';
 
@@ -136,6 +137,42 @@ describe('addressNL subfields validation', () => {
     expect(success).toBe(false);
     const message = error?.issues?.[0].message;
     expect(message).toBe('House number addition must be up to four letters and digits.');
+  });
+
+  test('prefers the custom pattern(s)/error messages when available', async () => {
+    const schema = buildValidationSchema({
+      ...BASE_COMPONENT,
+      validate: {required: false},
+      openForms: {
+        components: {
+          postcode: {
+            validate: {pattern: '1043 ?GR'},
+            errors: {pattern: 'Custom postcode error'},
+          },
+          city: {
+            validate: {pattern: 'Amsterdam|AMSTERDAM'},
+            errors: {pattern: 'Custom city error'},
+          },
+        },
+      },
+    });
+
+    const {success, error} = await schema.safeParseAsync({
+      postcode: '1234',
+      houseNumber: '3',
+      houseLetter: undefined,
+      HouseNumberAddition: undefined,
+      city: 'Utrecht',
+      streetName: 'Amsterdamsestraat',
+      secretStreetCity: 'foo',
+      autoPopulated: false,
+    });
+
+    expect(success).toBe(false);
+    const postcodeIssue = error?.issues?.find(issue => isEqual(issue.path, ['postcode']));
+    expect(postcodeIssue?.message).toBe('Custom postcode error');
+    const cityIssue = error?.issues?.find(issue => isEqual(issue.path, ['city']));
+    expect(cityIssue?.message).toBe('Custom city error');
   });
 });
 

--- a/src/registry/addressNL/validationSchema.ts
+++ b/src/registry/addressNL/validationSchema.ts
@@ -34,6 +34,11 @@ const HOUSE_NUMBER_ADDITION_INVALID_MESSAGE = defineMessage({
   defaultMessage: 'House number addition must be up to four letters and digits.',
 });
 
+const INVALID_AUTOFILL_ADDRESS_MESSAGE = defineMessage({
+  description: 'Validation error for empty address derivation result.',
+  defaultMessage: "The entered postcode and number don't result into a known address.",
+});
+
 interface PostcodeOptions {
   pattern: string | undefined;
   message: string | undefined;
@@ -198,6 +203,7 @@ const getValidationSchema: GetValidationSchema<AddressNLComponentSchema> = (
         .optional(),
       streetName: streetNameSchema,
       city: citySchema,
+      autoPopulated: z.boolean().optional(),
     })
     .superRefine(async (val, ctx) => {
       const postcodeOrHouseNumberProvided = Boolean(val.postcode || val.houseNumber);
@@ -223,8 +229,17 @@ const getValidationSchema: GetValidationSchema<AddressNLComponentSchema> = (
             path: ['postcode'],
           });
         }
+      }
 
-        if (deriveAddress && !val.streetName) {
+      if (postcodeOrHouseNumberProvided && deriveAddress) {
+        if (val.autoPopulated && !val.streetName && !val.city) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: intl.formatMessage(INVALID_AUTOFILL_ADDRESS_MESSAGE),
+          });
+        }
+
+        if (!val.autoPopulated && !val.streetName) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             message: buildRequiredMessage(intl, {
@@ -234,7 +249,7 @@ const getValidationSchema: GetValidationSchema<AddressNLComponentSchema> = (
           });
         }
 
-        if (deriveAddress && !val.city) {
+        if (!val.autoPopulated && !val.city) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             message: buildRequiredMessage(intl, {

--- a/src/registry/addressNL/validationSchema.ts
+++ b/src/registry/addressNL/validationSchema.ts
@@ -51,7 +51,9 @@ const buildPostcodeSchema = (
         fieldLabel: intl.formatMessage(FIELD_LABELS.postcode),
       }),
     })
-    .regex(DEFAULT_POSTCODE_REGEX, {message: defaultMessage});
+    // if a custom message is available, show it already as that provides the best
+    // feedback
+    .regex(DEFAULT_POSTCODE_REGEX, {message: message || defaultMessage});
   // add the custom pattern *on top of* the default pattern, which is always supposed to
   // be less strict than custom patterns
   if (pattern) {

--- a/src/registry/storybook-helpers.tsx
+++ b/src/registry/storybook-helpers.tsx
@@ -1,5 +1,6 @@
 import type {AnyComponentSchema} from '@open-formulieren/types';
 import type {StoryContext} from '@storybook/react-vite';
+import {useFormikContext} from 'formik';
 
 import {PrimaryActionButton} from '@/components/Button';
 import type {FormioFormProps} from '@/components/FormioForm';
@@ -28,9 +29,22 @@ export const renderComponentInForm = (args: RenderArgs, context?: StoryContext<u
       requiredFieldsWithAsterisk
       componentParameters={context?.parameters?.formSettings?.componentParameters}
       validatePluginCallback={context?.parameters?.formSettings?.validatePluginCallback}
-    />
-    <PrimaryActionButton type="submit" form="formio-form" style={{alignSelf: 'flex-start'}}>
-      Submit
-    </PrimaryActionButton>
+    >
+      <SubmitButton />
+    </FormioForm>
   </div>
 );
+
+const SubmitButton = () => {
+  const {isValid} = useFormikContext();
+  return (
+    <PrimaryActionButton
+      type="submit"
+      form="formio-form"
+      style={{alignSelf: 'flex-start', marginBlockStart: '24px'}}
+      data-is-valid={isValid ? 'true' : 'false'}
+    >
+      Submit
+    </PrimaryActionButton>
+  );
+};


### PR DESCRIPTION
Closes #256

- [x] Improved validation error handling when custom postcode validation error messages are configured
- [x] Ensure validation errors on the (read-only) city field are displayed if there are any
- [x] Display a useful message if no addresses could be resolved from the postcode / house number inputs (invalid address)
- [x] Fix validation state properly updating when error are corrected