### PR TITLE
Fixing map component interactions

### DIFF
--- a/src/components/map/LeafletMap.stories.tsx
+++ b/src/components/map/LeafletMap.stories.tsx
@@ -326,6 +326,7 @@ export const SingleInteractionMode: Story = {
 
 export const AllInteractions: Story = {
   args: {
+    onGeoJsonGeometrySet: fn(),
     interactions: {
       marker: true,
       polygon: true,
@@ -361,6 +362,7 @@ export const AllInteractions: Story = {
 
 export const WithCurrentLocationGranted: Story = {
   args: {
+    onGeoJsonGeometrySet: fn(),
     interactions: {
       marker: true,
       polygon: false,
@@ -404,6 +406,7 @@ export const WithCurrentLocationGranted: Story = {
 
 export const WithCurrentLocationDenied: Story = {
   args: {
+    onGeoJsonGeometrySet: fn(),
     interactions: {
       marker: true,
       polygon: false,
@@ -446,6 +449,7 @@ export const WithCurrentLocationDenied: Story = {
 
 export const WithCurrentLocationManuallyTogglePermission: Story = {
   args: {
+    onGeoJsonGeometrySet: fn(),
     interactions: {
       marker: true,
       polygon: false,

--- a/src/components/map/LeafletMap.tsx
+++ b/src/components/map/LeafletMap.tsx
@@ -354,15 +354,23 @@ interface MapBlurProps {
   onBlur: () => void;
 }
 
-const MapBlur: React.FC<MapBlurProps> = props => {
-  const {onBlur} = props;
-
+const MapBlur: React.FC<MapBlurProps> = ({onBlur}) => {
   const map = useMap();
   useEffect(() => {
-    map.on('blur', onBlur);
+    const container = map.getContainer();
+    const handleFocusOut = (event: FocusEvent) => {
+      const nextTarget = event.relatedTarget as Node | null;
+
+      // Ignore focus moving inside the map/draw controls
+      if (nextTarget && container.contains(nextTarget)) return;
+
+      onBlur();
+    };
+
+    container.addEventListener('focusout', handleFocusOut);
 
     return () => {
-      map.off('blur', onBlur);
+      container.removeEventListener('focusout', handleFocusOut);
     };
   }, [map, onBlur]);
   return null;


### PR DESCRIPTION
Closes open-formulieren/open-forms#6076

This PR fixes the issue where the leaflet map cannot be interacted with in a Open Formulieren form.

**TL;DR:** The issue was the implementation of the `onBlur` handler. The `map.on('blur', ...)` canceled all other map events, preventing the callbacks we use of map interaction from firing. I've changed the implementation to a `focusout` on the HTML component around the map element.

Kinda unrelated, but i noticed some of the Leaflet map stories didn't have all the needed arguments to allow interaction, so that is now also fixed. (This relates to my comment on https://github.com/open-formulieren/open-forms/issues/6076#issuecomment-4333316842, about the multiple interactions not working in the isolation mode storybook tests)

---

### More in depth details:

The on `blur` event listener directly on the map element overruled and canceled all other Leaflet map events, breaking the drawing of shapes.

In storybook we have Leaflet map stories and map component registry stories. The map component registry stories were working, because they didn't use the `onBlur` handler. The map component registry stories (which is the closest resemblance of how the map component is used in a actual form) didn't work because the `onBlur` handler.

The implementation of the `onBlur` handler has been changed to a `focusout` event listener on the container around the map element. This ensures other event can be fired, and allows bubbling up. The `focusout` handler contains some additional logic, where the `onBlur` handler is only called when you focus to outside the container.

Capturing/validating realistic actual user interaction is quite difficult. I've tried a couple different setup's, but couldn't create something that would work in a realistic manner.
(The map component registry `ValidateOnChange` story for some reason still worked while regular user interaction with actual events didn't. I've also tried a combination of `dispatchEvent` and `MouseEvent('click', ...)`, but that didn't represent realistic event based interaction either (i.e. it worked before I applied the `blur/focusout` fix))