### PR TITLE
[#6315] Add FAQ tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EUPL-1.2",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
-        "@open-formulieren/types": "^1.3.0",
+        "@open-formulieren/types": "^1.4.2",
         "clsx": "^2.1.0",
         "dompurify": "^3.4.11",
         "formik": "^2.4.5",
@@ -2214,9 +2214,9 @@
       }
     },
     "node_modules/@open-formulieren/types": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-1.3.0.tgz",
-      "integrity": "sha512-fSzo0glfvIJy0e23tjNst/eiPm+TgY/mD1jCsS9QpggdOQQe2MdEaj5h94yJTEZcgtlXyv9sOjEOVoKT4XKtmg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/types/-/types-1.4.2.tgz",
+      "integrity": "sha512-WLBk3FSEMsJFIHF/MnD7gBMk4Oi5ZdkY8LWAhYgjfSpJXYv94wIeoOtQqJ3UT/9kXzpoxi+VFEC4n9cikT/DVg==",
       "license": "EUPL-1.2"
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
@@ -2346,9 +2346,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2366,9 +2363,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2386,9 +2380,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2406,9 +2397,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2426,9 +2414,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2446,9 +2431,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2466,9 +2448,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2486,9 +2465,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2720,9 +2696,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2737,9 +2710,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2754,9 +2724,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2771,9 +2738,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2788,9 +2752,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2805,9 +2766,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2822,9 +2780,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2839,9 +2794,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.29.2",
-    "@open-formulieren/types": "^1.3.0",
+    "@open-formulieren/types": "^1.4.2",
     "clsx": "^2.1.0",
     "dompurify": "^3.4.11",
     "formik": "^2.4.5",

--- a/src/components/forms/Checkbox/Checkbox.scss
+++ b/src/components/forms/Checkbox/Checkbox.scss
@@ -109,6 +109,11 @@
         grid-column-end: description;
       }
 
+      .openforms-faq-items {
+        grid-column-start: input;
+        grid-column-end: description;
+      }
+
       // description for the option itself
       .utrecht-form-field-description:not(
         .utrecht-form-field-description--openforms-helptext,

--- a/src/components/forms/Checkbox/Checkbox.stories.ts
+++ b/src/components/forms/Checkbox/Checkbox.stories.ts
@@ -52,6 +52,31 @@ export const WithTooltip: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    isRequired: true,
+    faqItems: [
+      {
+        label: 'How do I fill in this field?',
+        content: 'The values required to fill out this field can be retrieved from XYZ.',
+      },
+      {
+        label: 'Is this field applicable to me?',
+        content: 'This field is applicable if you are XYZ.',
+      },
+    ],
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    const faqLabels1 = canvas.getByRole('button', {name: 'How do I fill in this field?'});
+    const faqLabels2 = canvas.getByRole('button', {name: 'Is this field applicable to me?'});
+
+    // Label should be visible underneath the fields
+    await expect(faqLabels1).toBeVisible();
+    await expect(faqLabels2).toBeVisible();
+  },
+};
+
 export const ValidationError: Story = {
   name: 'Validation error',
   args: {

--- a/src/components/forms/Checkbox/Checkbox.tsx
+++ b/src/components/forms/Checkbox/Checkbox.tsx
@@ -1,3 +1,4 @@
+import type {FAQItem} from '@open-formulieren/types';
 import {Checkbox as UtrechtCheckbox} from '@utrecht/checkbox-react';
 import {FormFieldDescription} from '@utrecht/form-field-description-react';
 import {FormField} from '@utrecht/form-field-react';
@@ -5,6 +6,7 @@ import {clsx} from 'clsx';
 import {useField, useFormikContext} from 'formik';
 import {useId} from 'react';
 
+import FAQItems from '@/components/forms/FAQItems';
 import HelpText from '@/components/forms/HelpText';
 import {LabelContent} from '@/components/forms/Label';
 import Tooltip from '@/components/forms/Tooltip';
@@ -58,6 +60,11 @@ export interface CheckboxProps {
    * assist users in filling out the field correctly.
    */
   tooltip?: React.ReactNode;
+  /**
+   * Optional FAQ tooltips to provide additional information that is not crucial but may
+   * assist users in filling out the field correctly.
+   */
+  faqItems?: FAQItem[];
 }
 
 const Checkbox: React.FC<CheckboxProps> = ({
@@ -69,6 +76,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
   isReadOnly = false,
   ignoreRequired = false,
   tooltip,
+  faqItems = [],
 }) => {
   const {validateField} = useFormikContext();
   name = useFieldConfig(name);
@@ -86,6 +94,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
   const descriptionId = description && !descriptionAsHelpText ? `${id}-description` : undefined;
 
   const ariaDescribedBy = [errorMessageId, descriptionId].filter(Boolean).join(' ');
+
   return (
     <FormField type="checkbox" invalid={invalid} className="utrecht-form-field--openforms">
       <UtrechtCheckbox
@@ -135,6 +144,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
       )}
 
       {touched && errorMessageId && <ValidationErrors error={error} id={errorMessageId} />}
+      <FAQItems items={faqItems} />
     </FormField>
   );
 };

--- a/src/components/forms/DateField/DateField.tsx
+++ b/src/components/forms/DateField/DateField.tsx
@@ -1,7 +1,9 @@
+import type {FAQItem} from '@open-formulieren/types';
 import {FormField} from '@utrecht/form-field-react';
 import {useFormikContext} from 'formik';
 import {useId} from 'react';
 
+import FAQItems from '@/components/forms/FAQItems';
 import HelpText from '@/components/forms/HelpText';
 import ValidationErrors from '@/components/forms/ValidationErrors';
 import {useFieldConfig, useFieldError} from '@/hooks';
@@ -81,6 +83,11 @@ interface DateFieldCommonProps {
    */
   tooltip?: React.ReactNode;
   /**
+   * Optional FAQ tooltips to provide additional information that is not crucial but may
+   * assist users in filling out the field correctly.
+   */
+  faqItems?: FAQItem[];
+  /**
    * How to autocomplete the field from the browser.
    */
   autoComplete?: string;
@@ -112,6 +119,7 @@ const DateField: React.FC<DateFieldProps> = ({
   tooltip,
   autoComplete,
   isMultiValue = false,
+  faqItems = [],
   ...props
 }) => {
   const id = useId();
@@ -159,6 +167,7 @@ const DateField: React.FC<DateFieldProps> = ({
       {dateInput}
       <HelpText>{description}</HelpText>
       {touched && errorMessageId && <ValidationErrors error={error} id={errorMessageId} />}
+      <FAQItems items={faqItems} />
     </FormField>
   );
 };

--- a/src/components/forms/DateField/DateInputGroup/DateField-InputGroup.stories.tsx
+++ b/src/components/forms/DateField/DateInputGroup/DateField-InputGroup.stories.tsx
@@ -38,6 +38,16 @@ export const InputGroup: Story = {
     label: 'Test date field',
     description: 'This is a custom description',
     tooltip: 'A short tooltip.',
+    faqItems: [
+      {
+        label: 'How do I fill in this field?',
+        content: 'The values required to fill out this field can be retrieved from XYZ.',
+      },
+      {
+        label: 'Is this field applicable to me?',
+        content: 'This field is applicable if you are XYZ.',
+      },
+    ],
     isReadOnly: false,
     isRequired: true,
   },
@@ -54,6 +64,12 @@ export const InputGroup: Story = {
     await expect(canvas.getByText('Month')).toBeVisible();
     await expect(canvas.getByText('Day')).toBeVisible();
     await expect(canvas.getByText('This is a custom description')).toBeVisible();
+
+    const faqLabels1 = canvas.getByRole('button', {name: 'How do I fill in this field?'});
+    const faqLabels2 = canvas.getByRole('button', {name: 'Is this field applicable to me?'});
+    // Label should be visible underneath the fields
+    await expect(faqLabels1).toBeVisible();
+    await expect(faqLabels2).toBeVisible();
 
     const inputsByName = Object.fromEntries(inputs.map(input => [input.name, input]));
 

--- a/src/components/forms/DateField/DatePicker/DateField-DatePicker.stories.tsx
+++ b/src/components/forms/DateField/DatePicker/DateField-DatePicker.stories.tsx
@@ -42,6 +42,16 @@ export const DatePicker: Story = {
     label: 'Date',
     description: 'This is a custom description',
     tooltip: 'A short tooltip.',
+    faqItems: [
+      {
+        label: 'How do I fill in this field?',
+        content: 'The values required to fill out this field can be retrieved from XYZ.',
+      },
+      {
+        label: 'Is this field applicable to me?',
+        content: 'This field is applicable if you are XYZ.',
+      },
+    ],
     isReadOnly: false,
     isRequired: true,
   },

--- a/src/components/forms/DateTimeField/DateTimeField.stories.tsx
+++ b/src/components/forms/DateTimeField/DateTimeField.stories.tsx
@@ -40,6 +40,16 @@ export const Default: Story = {
     label: 'Datetime',
     description: 'This is a custom description',
     tooltip: 'A short tooltip.',
+    faqItems: [
+      {
+        label: 'How do I fill in this field?',
+        content: 'The values required to fill out this field can be retrieved from XYZ.',
+      },
+      {
+        label: 'Is this field applicable to me?',
+        content: 'This field is applicable if you are XYZ.',
+      },
+    ],
     isReadOnly: false,
     isRequired: true,
   },

--- a/src/components/forms/DateTimeField/DateTimeField.tsx
+++ b/src/components/forms/DateTimeField/DateTimeField.tsx
@@ -1,3 +1,4 @@
+import type {FAQItem} from '@open-formulieren/types';
 import {Paragraph} from '@utrecht/component-library-react';
 import {FormField} from '@utrecht/form-field-react';
 import {Textbox} from '@utrecht/textbox-react';
@@ -7,6 +8,7 @@ import {useEffect, useId, useState} from 'react';
 import {useIntl} from 'react-intl';
 
 import {DatePicker, DatePickerRoot, DatePickerTrigger} from '@/components/forms/DatePicker';
+import FAQItems from '@/components/forms/FAQItems';
 import HelpText from '@/components/forms/HelpText';
 import Label from '@/components/forms/Label';
 import Tooltip from '@/components/forms/Tooltip';
@@ -49,6 +51,11 @@ export interface DateTimeFieldProps {
    * assist users in filling out the field correctly.
    */
   tooltip?: React.ReactNode;
+  /**
+   * Optional FAQ tooltips to provide additional information that is not crucial but may
+   * assist users in filling out the field correctly.
+   */
+  faqItems?: FAQItem[];
   /**
    * Earliest date that is selectable in the calendar.
    */
@@ -106,6 +113,7 @@ const DateTimeField: React.FC<DateTimeFieldProps> = ({
   maxDate,
   'aria-describedby': ariaDescribedBy,
   isMultiValue = false,
+  faqItems = [],
 }) => {
   name = useFieldConfig(name);
   const id = useId();
@@ -275,6 +283,7 @@ const DateTimeField: React.FC<DateTimeFieldProps> = ({
 
       <HelpText>{description}</HelpText>
       {touched && errorMessageId && <ValidationErrors error={error} id={errorMessageId} />}
+      <FAQItems items={faqItems} />
     </FormField>
   );
 };

--- a/src/components/forms/EditGrid/EditGrid.stories.tsx
+++ b/src/components/forms/EditGrid/EditGrid.stories.tsx
@@ -74,6 +74,30 @@ export const WithTooltip: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    faqItems: [
+      {
+        label: 'How do I fill in this field?',
+        content: 'The values required to fill out this field can be retrieved from XYZ.',
+      },
+      {
+        label: 'Is this field applicable to me?',
+        content: 'This field is applicable if you are XYZ.',
+      },
+    ],
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    const faqLabels1 = canvas.getByRole('button', {name: 'How do I fill in this field?'});
+    const faqLabels2 = canvas.getByRole('button', {name: 'Is this field applicable to me?'});
+
+    // Label should be visible underneath the fields
+    await expect(faqLabels1).toBeVisible();
+    await expect(faqLabels2).toBeVisible();
+  },
+};
+
 export const WithCustomButtonLabels: Story = {
   args: {
     enableIsolation: true,

--- a/src/components/forms/EditGrid/EditGrid.tsx
+++ b/src/components/forms/EditGrid/EditGrid.tsx
@@ -1,3 +1,4 @@
+import type {FAQItem} from '@open-formulieren/types';
 import {ButtonGroup} from '@utrecht/button-group-react';
 import {FormField} from '@utrecht/form-field-react';
 import {FieldArray, getIn, setIn, useFormikContext} from 'formik';
@@ -9,6 +10,7 @@ import type {ValidationError} from 'zod-formik-adapter';
 
 import {SecondaryActionButton} from '@/components/Button';
 import FieldConfigProvider from '@/components/FieldConfigProvider';
+import FAQItems from '@/components/forms/FAQItems';
 import HelpText from '@/components/forms/HelpText';
 import Label from '@/components/forms/Label';
 import Tooltip from '@/components/forms/Tooltip';
@@ -46,6 +48,11 @@ interface EditGridBaseProps<T> {
    * assist users in filling out the field correctly.
    */
   tooltip?: React.ReactNode;
+  /**
+   * Optional FAQ tooltips to provide additional information that is not crucial but may
+   * assist users in filling out the field correctly.
+   */
+  faqItems?: FAQItem[];
   /**
    * Callback to return the heading for a single item. Gets passed the item values and
    * index in the array of values.
@@ -125,6 +132,7 @@ function EditGrid<T extends {[K in keyof T]: JSONValue} = JSONObject>({
   tooltip,
   getItemHeading,
   canRemoveItem,
+  faqItems = [],
   removeItemLabel = '',
   emptyItem = null,
   addButtonLabel = '',
@@ -259,6 +267,7 @@ function EditGrid<T extends {[K in keyof T]: JSONValue} = JSONObject>({
       {hasFieldLevelError && errorMessageId && (
         <ValidationErrors error={error} id={errorMessageId} />
       )}
+      <FAQItems items={faqItems} />
     </FormField>
   );
 }

--- a/src/components/forms/FAQItem.scss
+++ b/src/components/forms/FAQItem.scss
@@ -1,0 +1,26 @@
+@use '@utrecht/icon-css';
+@use '@utrecht/link-button-css';
+
+@use '@/scss/bem';
+
+.openforms-faq-items {
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--of-faq-items-row-gap, 8px);
+  align-items: flex-start;
+  padding-block-start: var(--of-faq-items-padding-block-start, 8px);
+}
+
+.openforms-faq-item {
+  @include bem.element('title') {
+    color: var(--of-faq-item-title-color);
+    font-size: var(--of-faq-item-title-font-size);
+    font-weight: var(--of-faq-item-title-font-weight);
+    line-height: var(--of-faq-item-title-line-height);
+    text-decoration: var(--of-faq-item-title-text-decoration);
+
+    &:hover {
+      text-decoration: var(--of-faq-item-title-hover-text-decoration);
+    }
+  }
+}

--- a/src/components/forms/FAQItems.stories.tsx
+++ b/src/components/forms/FAQItems.stories.tsx
@@ -1,0 +1,40 @@
+import type {Meta, StoryObj} from '@storybook/react-vite';
+
+import FAQItems from './FAQItems';
+
+export default {
+  title: 'Internal API / Forms / FAQ items',
+  component: FAQItems,
+  args: {
+    items: [
+      {
+        label: 'Title text',
+        content: 'HTML content inside the <strong>tooltip</strong>',
+        openForms: {
+          translations: {
+            en: {
+              label: 'Title text',
+              content: 'HTML content inside the <strong>tooltip</strong>',
+            },
+          },
+        },
+      },
+      {
+        label: 'Other title text',
+        content: 'HTML content inside the <strong>tooltip</strong>',
+        openForms: {
+          translations: {
+            en: {
+              label: 'Other title text',
+              content: 'HTML content inside the <strong>tooltip</strong>',
+            },
+          },
+        },
+      },
+    ],
+  },
+} satisfies Meta<typeof FAQItems>;
+
+type Story = StoryObj<typeof FAQItems>;
+
+export const Default: Story = {};

--- a/src/components/forms/FAQItems.tsx
+++ b/src/components/forms/FAQItems.tsx
@@ -1,0 +1,59 @@
+import type {FAQItem as FAQItemType} from '@open-formulieren/types';
+import {HTMLContent, LinkButton, Icon as UtrechtIcon} from '@utrecht/component-library-react';
+import Modal from 'components/modal';
+import DOMPurify from 'dompurify';
+import {useMemo, useState} from 'react';
+
+import Icon from '@/components/icons';
+
+import './FAQItem.scss';
+
+export interface FAQItemsProps {
+  /**
+   * FAQ tooltips to provide additional information that is not crucial but may
+   * assist users in filling out the field correctly.
+   */
+  items: FAQItemType[];
+}
+
+export interface FAQItemProps {
+  label: string;
+  content: string;
+}
+
+const FAQItem: React.FC<FAQItemProps> = ({label, content}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const sanitizedContent = useMemo(() => {
+    return DOMPurify.sanitize(content, {USE_PROFILES: {html: true}});
+  }, [content]);
+  const modalSheet = (
+    <Modal title={label} variant="sheet" closeModal={() => setIsOpen(false)} isOpen={isOpen}>
+      <HTMLContent dangerouslySetInnerHTML={{__html: sanitizedContent}} />
+    </Modal>
+  );
+
+  return (
+    <>
+      <LinkButton className="openforms-faq-item" onClick={() => setIsOpen(true)}>
+        <UtrechtIcon>
+          <Icon icon="tooltip" />
+        </UtrechtIcon>
+
+        <span className="openforms-faq-item__title">{label}</span>
+      </LinkButton>
+      {modalSheet}
+    </>
+  );
+};
+
+const FAQItems: React.FC<FAQItemsProps> = ({items}) => {
+  if (!items.length) return null;
+
+  const faqElements = items.map(({label, content}, index) => (
+    <FAQItem key={index} label={label} content={content} />
+  ));
+  return <div className="openforms-faq-items">{faqElements}</div>;
+};
+
+export default FAQItems;

--- a/src/components/forms/MultiField.stories.tsx
+++ b/src/components/forms/MultiField.stories.tsx
@@ -78,6 +78,37 @@ export const WithDescriptionAndTooltip: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    faqItems: [
+      {
+        label: 'How do I fill in this field?',
+        content: 'The values required to fill out this field can be retrieved from XYZ.',
+      },
+      {
+        label: 'Is this field applicable to me?',
+        content: 'This field is applicable if you are XYZ.',
+      },
+    ],
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        test: ['First', 'Second'],
+      },
+    },
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    const faqLabels1 = canvas.getByRole('button', {name: 'How do I fill in this field?'});
+    const faqLabels2 = canvas.getByRole('button', {name: 'Is this field applicable to me?'});
+
+    // Label should be visible underneath the fields
+    await expect(faqLabels1).toBeVisible();
+    await expect(faqLabels2).toBeVisible();
+  },
+};
+
 export const ItemValidationError: Story = {
   parameters: {
     formik: {

--- a/src/components/forms/MultiField.tsx
+++ b/src/components/forms/MultiField.tsx
@@ -1,3 +1,4 @@
+import type {FAQItem} from '@open-formulieren/types';
 import {ButtonGroup} from '@utrecht/button-group-react';
 import {Icon as UtrechtIcon} from '@utrecht/component-library-react';
 import {Fieldset, FieldsetLegend} from '@utrecht/fieldset-react';
@@ -7,6 +8,7 @@ import {useEffect, useId, useRef} from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import {Button, SecondaryActionButton} from '@/components/Button';
+import FAQItems from '@/components/forms/FAQItems';
 import HelpText from '@/components/forms/HelpText';
 import {LabelContent} from '@/components/forms/Label';
 import Tooltip from '@/components/forms/Tooltip';
@@ -69,6 +71,11 @@ export interface MultiFieldProps<T extends MultiFieldValue> {
    */
   tooltip?: React.ReactNode;
   /**
+   * Optional FAQ tooltips to provide additional information that is not crucial but may
+   * assist users in filling out the field correctly.
+   */
+  faqItems?: FAQItem[];
+  /**
    * Optional callback invoked when a new item is added that should receive auto focus.
    *
    * If provided, you receive the Formik field name of the inserted item, e.g. `myField.3`.
@@ -111,6 +118,7 @@ function MultiField<T extends MultiFieldValue>({
   description,
   tooltip,
   getAutoFocusQuerySelector,
+  faqItems = [],
 }: MultiFieldProps<T>) {
   const {getFieldProps, setFieldError, getFieldMeta, touched} = useFormikContext<JSONObject>();
   const {value: formikItems} = getFieldProps<T[] | undefined>(name);
@@ -222,6 +230,7 @@ function MultiField<T extends MultiFieldValue>({
 
       <HelpText id={descriptionid}>{description}</HelpText>
       {anyItemTouched && errorMessageId && <ValidationErrors error={error} id={errorMessageId} />}
+      <FAQItems items={faqItems} />
     </Fieldset>
   );
 }

--- a/src/components/forms/NumberField/NumberField.stories.tsx
+++ b/src/components/forms/NumberField/NumberField.stories.tsx
@@ -45,6 +45,35 @@ export const Default: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    name: 'number',
+    label: 'Number',
+    description: 'This is a custom description for the number field',
+    isReadOnly: false,
+    isRequired: false,
+    faqItems: [
+      {
+        label: 'How do I fill in this field?',
+        content: 'The values required to fill out this field can be retrieved from XYZ.',
+      },
+      {
+        label: 'Is this field applicable to me?',
+        content: 'This field is applicable if you are XYZ.',
+      },
+    ],
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    const faqLabels1 = canvas.getByRole('button', {name: 'How do I fill in this field?'});
+    const faqLabels2 = canvas.getByRole('button', {name: 'Is this field applicable to me?'});
+
+    // Label should be visible underneath the fields
+    await expect(faqLabels1).toBeVisible();
+    await expect(faqLabels2).toBeVisible();
+  },
+};
+
 export const Readonly: Story = {
   args: {
     name: 'number',

--- a/src/components/forms/NumberField/NumberField.tsx
+++ b/src/components/forms/NumberField/NumberField.tsx
@@ -1,3 +1,4 @@
+import type {FAQItem} from '@open-formulieren/types';
 import {FormField} from '@utrecht/form-field-react';
 import {Textbox} from '@utrecht/textbox-react';
 import {useField, useFormikContext} from 'formik';
@@ -5,6 +6,7 @@ import {useId} from 'react';
 import {useIntl} from 'react-intl';
 import {NumericFormat} from 'react-number-format';
 
+import FAQItems from '@/components/forms/FAQItems';
 import HelpText from '@/components/forms/HelpText';
 import InputContainer from '@/components/forms/InputContainer';
 import Label from '@/components/forms/Label';
@@ -48,6 +50,11 @@ export interface NumberFieldProps {
    * assist users in filling out the field correctly.
    */
   tooltip?: React.ReactNode;
+  /**
+   * Optional FAQ tooltips to provide additional information that is not crucial but may
+   * assist users in filling out the field correctly.
+   */
+  faqItems?: FAQItem[];
   /**
    * Maximum number of decimals of the input.
    */
@@ -126,6 +133,7 @@ const NumberField: React.FC<NumberFieldProps> = ({
   useThousandSeparator = false,
   fixedDecimalScale = false,
   isMultiValue = false,
+  faqItems = [],
   ...extraProps
 }) => {
   name = useFieldConfig(name);
@@ -199,6 +207,7 @@ const NumberField: React.FC<NumberFieldProps> = ({
 
       <HelpText>{description}</HelpText>
       {touched && errorMessageId && <ValidationErrors error={error} id={errorMessageId} />}
+      <FAQItems items={faqItems} />
     </FormField>
   );
 };

--- a/src/components/forms/RadioField/RadioField.stories.ts
+++ b/src/components/forms/RadioField/RadioField.stories.ts
@@ -56,6 +56,31 @@ export const WithTooltip: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    isRequired: true,
+    faqItems: [
+      {
+        label: 'How do I fill in this field?',
+        content: 'The values required to fill out this field can be retrieved from XYZ.',
+      },
+      {
+        label: 'Is this field applicable to me?',
+        content: 'This field is applicable if you are XYZ.',
+      },
+    ],
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    const faqLabels1 = canvas.getByRole('button', {name: 'How do I fill in this field?'});
+    const faqLabels2 = canvas.getByRole('button', {name: 'Is this field applicable to me?'});
+
+    // Label should be visible underneath the fields
+    await expect(faqLabels1).toBeVisible();
+    await expect(faqLabels2).toBeVisible();
+  },
+};
+
 export const ValidationError: Story = {
   name: 'Validation error',
   args: {

--- a/src/components/forms/RadioField/RadioField.tsx
+++ b/src/components/forms/RadioField/RadioField.tsx
@@ -1,8 +1,10 @@
+import type {FAQItem} from '@open-formulieren/types';
 import {Fieldset, FieldsetLegend} from '@utrecht/fieldset-react';
 import {clsx} from 'clsx';
 import {useField, useFormikContext} from 'formik';
 import {useEffect, useId, useLayoutEffect, useRef} from 'react';
 
+import FAQItems from '@/components/forms/FAQItems';
 import HelpText from '@/components/forms/HelpText';
 import {LabelContent} from '@/components/forms/Label';
 import Tooltip from '@/components/forms/Tooltip';
@@ -41,6 +43,11 @@ interface BasicRadioFieldProps {
    * Array of possible choices for the field. Only one can be selected.
    */
   options: RadioOption[];
+  /**
+   * Optional FAQ tooltips to provide additional information that is not crucial but may
+   * assist users in filling out the field correctly.
+   */
+  faqItems?: FAQItem[];
 }
 
 type RadioFieldWithLabelProps = BasicRadioFieldProps & {
@@ -86,6 +93,7 @@ const RadioField: React.FC<RadioFieldProps> = ({
   isReadOnly = false,
   options = [],
   tooltip,
+  faqItems = [],
 }) => {
   name = useFieldConfig(name);
   const {validateField, getFieldProps} = useFormikContext();
@@ -208,6 +216,7 @@ const RadioField: React.FC<RadioFieldProps> = ({
 
       <HelpText id={descriptionId}>{description}</HelpText>
       {touched && errorMessageId && <ValidationErrors error={error} id={errorMessageId} />}
+      <FAQItems items={faqItems} />
     </Fieldset>
   );
 };

--- a/src/components/forms/Select/Select.stories.ts
+++ b/src/components/forms/Select/Select.stories.ts
@@ -121,6 +121,35 @@ export const WithTooltip: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    name: 'test',
+    label: 'test',
+    description: 'This is a custom description',
+    isReadOnly: false,
+    isRequired: true,
+    faqItems: [
+      {
+        label: 'How do I fill in this field?',
+        content: 'The values required to fill out this field can be retrieved from XYZ.',
+      },
+      {
+        label: 'Is this field applicable to me?',
+        content: 'This field is applicable if you are XYZ.',
+      },
+    ],
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    const faqLabels1 = canvas.getByRole('button', {name: 'How do I fill in this field?'});
+    const faqLabels2 = canvas.getByRole('button', {name: 'Is this field applicable to me?'});
+
+    // Label should be visible underneath the fields
+    await expect(faqLabels1).toBeVisible();
+    await expect(faqLabels2).toBeVisible();
+  },
+};
+
 export const ValidationError: Story = {
   name: 'Validation error',
   parameters: {

--- a/src/components/forms/Select/Select.tsx
+++ b/src/components/forms/Select/Select.tsx
@@ -1,8 +1,10 @@
+import type {FAQItem} from '@open-formulieren/types';
 import {FormField} from '@utrecht/form-field-react';
 import {useField, useFormikContext} from 'formik';
 import {useEffect, useId} from 'react';
 import type {MultiValue, OptionProps, SingleValue} from 'react-select';
 
+import FAQItems from '@/components/forms/FAQItems';
 import HelpText from '@/components/forms/HelpText';
 import Label from '@/components/forms/Label';
 import Tooltip from '@/components/forms/Tooltip';
@@ -66,6 +68,11 @@ export interface SelectProps {
    */
   tooltip?: React.ReactNode;
   /**
+   * Optional FAQ tooltips to provide additional information that is not crucial but may
+   * assist users in filling out the field correctly.
+   */
+  faqItems?: FAQItem[];
+  /**
    * Formio compatibility - a select without any option chosen is represented as empty
    * string in Formio submission data, instead of `null` or `undefined`. The default
    * is to use `undefined` to remove the value from the Formik state entirely.
@@ -92,6 +99,7 @@ const Select: React.FC<SelectProps> = ({
   tooltip,
   noOptionSelectedValue = undefined,
   optionComponent,
+  faqItems = [],
 }) => {
   name = useFieldConfig(name);
   const {validateField} = useFormikContext();
@@ -177,6 +185,7 @@ const Select: React.FC<SelectProps> = ({
       />
       <HelpText>{description}</HelpText>
       {touched && errorMessageId && <ValidationErrors error={error} id={errorMessageId} />}
+      <FAQItems items={faqItems} />
     </FormField>
   );
 };

--- a/src/components/forms/TextField/TextField.stories.ts
+++ b/src/components/forms/TextField/TextField.stories.ts
@@ -52,6 +52,35 @@ export const WithTooltip: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    name: 'test',
+    label: 'test',
+    description: 'This is a custom description',
+    isReadOnly: false,
+    isRequired: true,
+    faqItems: [
+      {
+        label: 'How do I fill in this field?',
+        content: 'The values required to fill out this field can be retrieved from XYZ.',
+      },
+      {
+        label: 'Is this field applicable to me?',
+        content: 'This field is applicable if you are XYZ.',
+      },
+    ],
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    const faqLabels1 = canvas.getByRole('button', {name: 'How do I fill in this field?'});
+    const faqLabels2 = canvas.getByRole('button', {name: 'Is this field applicable to me?'});
+
+    // Label should be visible underneath the fields
+    await expect(faqLabels1).toBeVisible();
+    await expect(faqLabels2).toBeVisible();
+  },
+};
+
 export const ReadOnly: Story = {
   args: {
     name: 'test',

--- a/src/components/forms/TextField/TextField.tsx
+++ b/src/components/forms/TextField/TextField.tsx
@@ -1,3 +1,4 @@
+import type {FAQItem} from '@open-formulieren/types';
 import {Paragraph} from '@utrecht/component-library-react';
 import {FormField} from '@utrecht/form-field-react';
 import type {TextboxProps} from '@utrecht/textbox-react';
@@ -6,6 +7,7 @@ import {useField, useFormikContext} from 'formik';
 import {useId} from 'react';
 
 import CharCount from '@/components/forms/CharCount';
+import FAQItems from '@/components/forms/FAQItems';
 import HelpText from '@/components/forms/HelpText';
 import Label from '@/components/forms/Label';
 import Tooltip from '@/components/forms/Tooltip';
@@ -45,6 +47,11 @@ export interface TextFieldProps {
    * assist users in filling out the field correctly.
    */
   tooltip?: React.ReactNode;
+  /**
+   * Optional FAQ tooltips to provide additional information that is not crucial but may
+   * assist users in filling out the field correctly.
+   */
+  faqItems?: FAQItem[];
   /**
    * Placeholder when no (default) value is available.
    */
@@ -93,6 +100,7 @@ const TextField: React.FC<TextFieldProps & TextboxProps> = ({
   showCharCount = false,
   isMultiValue = false,
   nameForValidate = undefined,
+  faqItems = [],
   children,
   ...extraProps
 }) => {
@@ -147,6 +155,7 @@ const TextField: React.FC<TextFieldProps & TextboxProps> = ({
       {children}
       <HelpText>{description}</HelpText>
       {touched && errorMessageId && <ValidationErrors error={error} id={errorMessageId} />}
+      <FAQItems items={faqItems} />
     </FormField>
   );
 };

--- a/src/components/forms/Textarea/Textarea.stories.ts
+++ b/src/components/forms/Textarea/Textarea.stories.ts
@@ -52,6 +52,35 @@ export const WithTooltip: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    name: 'test',
+    label: 'test',
+    description: 'This is a custom description',
+    isReadOnly: false,
+    isRequired: true,
+    faqItems: [
+      {
+        label: 'How do I fill in this field?',
+        content: 'The values required to fill out this field can be retrieved from XYZ.',
+      },
+      {
+        label: 'Is this field applicable to me?',
+        content: 'This field is applicable if you are XYZ.',
+      },
+    ],
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    const faqLabels1 = canvas.getByRole('button', {name: 'How do I fill in this field?'});
+    const faqLabels2 = canvas.getByRole('button', {name: 'Is this field applicable to me?'});
+
+    // Label should be visible underneath the fields
+    await expect(faqLabels1).toBeVisible();
+    await expect(faqLabels2).toBeVisible();
+  },
+};
+
 export const ValidationError: Story = {
   name: 'Validation error',
   parameters: {

--- a/src/components/forms/Textarea/Textarea.tsx
+++ b/src/components/forms/Textarea/Textarea.tsx
@@ -1,3 +1,4 @@
+import type {FAQItem} from '@open-formulieren/types';
 import {Paragraph, Textarea as UtrechtTextarea} from '@utrecht/component-library-react';
 import type {TextareaProps as UtrechtTextareaProps} from '@utrecht/component-library-react';
 import {FormField} from '@utrecht/form-field-react';
@@ -6,6 +7,7 @@ import {useField, useFormikContext} from 'formik';
 import {useId, useLayoutEffect, useRef} from 'react';
 
 import CharCount from '@/components/forms/CharCount';
+import FAQItems from '@/components/forms/FAQItems';
 import HelpText from '@/components/forms/HelpText';
 import Label from '@/components/forms/Label';
 import Tooltip from '@/components/forms/Tooltip';
@@ -46,6 +48,11 @@ export interface TextareaProps {
    */
   tooltip?: React.ReactNode;
   /**
+   * Optional FAQ tooltips to provide additional information that is not crucial but may
+   * assist users in filling out the field correctly.
+   */
+  faqItems?: FAQItem[];
+  /**
    * Placeholder when no (default) value is available.
    */
   placeholder?: string;
@@ -81,6 +88,7 @@ const Textarea: React.FC<TextareaProps & UtrechtTextareaProps> = ({
   maxLength,
   showCharCount = false,
   isMultiValue = false,
+  faqItems = [],
   ...extraProps
 }) => {
   name = useFieldConfig(name);
@@ -151,6 +159,7 @@ const Textarea: React.FC<TextareaProps & UtrechtTextareaProps> = ({
       )}
       <HelpText>{description}</HelpText>
       {touched && errorMessageId && <ValidationErrors error={error} id={errorMessageId} />}
+      <FAQItems items={faqItems} />
     </FormField>
   );
 };

--- a/src/registry/addressNL/index.stories.tsx
+++ b/src/registry/addressNL/index.stories.tsx
@@ -139,6 +139,48 @@ export const WithoutLabel: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'addressNL',
+      key: 'my.address',
+      label: 'Your address',
+      deriveAddress: false,
+      layout: 'doubleColumn',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+    } satisfies AddressNLComponentSchema,
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          address: {
+            postcode: '',
+            houseNumber: '',
+            houseLetter: '',
+            houseNumberAddition: '',
+            // optional properties depending on the features used
+            city: undefined,
+            streetName: undefined,
+            secretStreetCity: undefined,
+            autoPopulated: undefined,
+          } satisfies AddressData,
+        },
+      },
+    },
+  },
+};
+
 export const WithDescriptionAndTooltip: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/addressNL/index.tsx
+++ b/src/registry/addressNL/index.tsx
@@ -4,6 +4,7 @@ import {getIn, useFormikContext} from 'formik';
 import type {FormikErrors} from 'formik';
 import {useId} from 'react';
 
+import FAQItems from '@/components/forms/FAQItems';
 import Fieldset from '@/components/forms/Fieldset';
 import HelpText from '@/components/forms/HelpText';
 import Tooltip from '@/components/forms/Tooltip';
@@ -41,6 +42,7 @@ export const FormioAddressNL: React.FC<FormioAddressNLProps> = ({
     validate,
     layout = 'doubleColumn',
     deriveAddress = false,
+    faqItems = [],
   },
 }) => {
   const {values, errors, getFieldMeta} = useFormikContext<FormValues>();
@@ -118,6 +120,8 @@ export const FormioAddressNL: React.FC<FormioAddressNLProps> = ({
       {touched && errorMessageId && addressError && (
         <ValidationErrors error={addressError} id={errorMessageId} />
       )}
+
+      <FAQItems items={faqItems} />
     </Fieldset>
   );
 };

--- a/src/registry/bsn/index.stories.tsx
+++ b/src/registry/bsn/index.stories.tsx
@@ -59,6 +59,36 @@ export const WithTooltip: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'bsn',
+      key: 'my.bsn',
+      label: 'A BSN field',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+    } satisfies BsnComponentSchema,
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          bsn: '',
+        },
+      },
+    },
+  },
+};
+
 export const Multiple: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/bsn/index.tsx
+++ b/src/registry/bsn/index.tsx
@@ -14,10 +14,10 @@ export interface FormioBSNProps {
 }
 
 export const FormioBSN: React.FC<FormioBSNProps> = ({componentDefinition}) => {
-  const {key, label, tooltip, description, validate, disabled} = componentDefinition;
+  const {key, label, tooltip, faqItems, description, validate, disabled} = componentDefinition;
   const sharedProps: Pick<
     React.ComponentProps<typeof TextField>,
-    'name' | 'label' | 'description' | 'tooltip' | 'isRequired' | 'isReadOnly'
+    'name' | 'label' | 'description' | 'tooltip' | 'isRequired' | 'isReadOnly' | 'faqItems'
   > = {
     name: key,
     label,
@@ -25,6 +25,7 @@ export const FormioBSN: React.FC<FormioBSNProps> = ({componentDefinition}) => {
     tooltip,
     isRequired: validate?.required,
     isReadOnly: disabled,
+    faqItems,
   };
 
   return componentDefinition.multiple ? (

--- a/src/registry/checkbox/index.stories.tsx
+++ b/src/registry/checkbox/index.stories.tsx
@@ -60,6 +60,37 @@ export const WithTooltip: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'checkbox',
+      key: 'my.checkbox',
+      label: 'A simple checkbox',
+      defaultValue: false,
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          checkbox: false,
+        },
+      },
+    },
+  },
+};
+
 export const WithDescription: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/checkbox/index.tsx
+++ b/src/registry/checkbox/index.tsx
@@ -13,7 +13,7 @@ export interface FormioCheckboxProps {
 }
 
 export const FormioCheckbox: React.FC<FormioCheckboxProps> = ({
-  componentDefinition: {key, label, description, tooltip, validate},
+  componentDefinition: {key, label, description, tooltip, faqItems, validate},
 }) => {
   return (
     <Checkbox
@@ -22,6 +22,7 @@ export const FormioCheckbox: React.FC<FormioCheckboxProps> = ({
       tooltip={tooltip}
       description={description}
       isRequired={validate?.required}
+      faqItems={faqItems}
     />
   );
 };

--- a/src/registry/children/index.stories.tsx
+++ b/src/registry/children/index.stories.tsx
@@ -42,6 +42,42 @@ export const MinimalConfiguration: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'children',
+      type: 'children',
+      key: 'children',
+      label: 'Children',
+      enableSelection: false,
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        children: [
+          {
+            bsn: '111222333',
+            firstNames: 'John Doe',
+            dateOfBirth: '2000-1-1',
+            selected: null,
+          },
+        ],
+      },
+    },
+  },
+};
+
 export const WithTooltipAndDescription: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/children/index.tsx
+++ b/src/registry/children/index.tsx
@@ -5,6 +5,7 @@ import {useEffect, useId, useState} from 'react';
 import {FormattedMessage} from 'react-intl';
 
 import {SecondaryActionButton} from '@/components/Button';
+import FAQItems from '@/components/forms/FAQItems';
 import Fieldset from '@/components/forms/Fieldset';
 import HelpText from '@/components/forms/HelpText';
 import Tooltip from '@/components/forms/Tooltip';
@@ -28,7 +29,7 @@ export interface FormioChildrenFieldProps {
 }
 
 export const FormioChildrenField: React.FC<FormioChildrenFieldProps> = ({
-  componentDefinition: {key, label, description, tooltip, enableSelection},
+  componentDefinition: {key, label, description, tooltip, faqItems = [], enableSelection},
 }) => {
   const id = useId();
   key = useFieldConfig(key);
@@ -145,6 +146,8 @@ export const FormioChildrenField: React.FC<FormioChildrenFieldProps> = ({
           />
         </SecondaryActionButton>
       )}
+
+      <FAQItems items={faqItems} />
     </Fieldset>
   );
 };

--- a/src/registry/cosign/index.stories.tsx
+++ b/src/registry/cosign/index.stories.tsx
@@ -35,6 +35,34 @@ export const MinimalConfiguration: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'cosign',
+      type: 'cosign',
+      key: 'cosign',
+      label: 'Co-signer email address',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        cosign: '',
+      },
+    },
+  },
+};
+
 export const WithTooltip: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/cosign/index.tsx
+++ b/src/registry/cosign/index.tsx
@@ -13,7 +13,7 @@ export interface FormioCosignProps {
 }
 
 export const FormioCosign: React.FC<FormioCosignProps> = ({
-  componentDefinition: {key, label, description, tooltip, validate, autocomplete},
+  componentDefinition: {key, label, description, tooltip, validate, autocomplete, faqItems},
 }) => {
   return (
     <TextField
@@ -24,6 +24,7 @@ export const FormioCosign: React.FC<FormioCosignProps> = ({
       tooltip={tooltip}
       isRequired={validate?.required}
       autoComplete={autocomplete}
+      faqItems={faqItems}
     />
   );
 };

--- a/src/registry/currency/index.stories.tsx
+++ b/src/registry/currency/index.stories.tsx
@@ -74,6 +74,35 @@ export const MinimalConfigurationWithEnglishLocale: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'currency',
+      type: 'currency',
+      key: 'currency',
+      label: 'Currency',
+      currency: 'EUR',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        currency: null,
+      },
+    },
+  },
+};
+
 export const WithTooltip: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/currency/index.tsx
+++ b/src/registry/currency/index.tsx
@@ -39,6 +39,7 @@ export const FormioCurrencyField: React.FC<FormioCurrencyFieldProps> = ({
     currency,
     decimalLimit = 2,
     allowNegative,
+    faqItems,
   },
 }) => {
   const {locale} = useIntl();
@@ -57,6 +58,7 @@ export const FormioCurrencyField: React.FC<FormioCurrencyFieldProps> = ({
       valuePrefix={currencySymbol}
       useThousandSeparator
       fixedDecimalScale
+      faqItems={faqItems}
     />
   );
 };

--- a/src/registry/customerProfile/index.stories.tsx
+++ b/src/registry/customerProfile/index.stories.tsx
@@ -55,6 +55,29 @@ export const WithTooltipAndDescription: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'customerProfile',
+      type: 'customerProfile',
+      key: 'customerProfile',
+      label: 'Profile',
+      digitalAddressTypes: ['email', 'phoneNumber'],
+      shouldUpdateCustomerData: false,
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+    },
+  },
+};
+
 export const WithInitialValue: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/customerProfile/index.tsx
+++ b/src/registry/customerProfile/index.tsx
@@ -7,6 +7,7 @@ import {useId} from 'react';
 import FormFieldContainer from '@/components/FormFieldContainer';
 import LoadingIndicator from '@/components/LoadingIndicator';
 import {ValidationErrors} from '@/components/forms';
+import FAQItems from '@/components/forms/FAQItems';
 import Fieldset from '@/components/forms/Fieldset';
 import HelpText from '@/components/forms/HelpText';
 import Tooltip from '@/components/forms/Tooltip';
@@ -28,7 +29,15 @@ export interface FormioCustomerProfileProps {
 }
 
 export const FormioCustomerProfile: React.FC<FormioCustomerProfileProps> = ({
-  componentDefinition: {key: name, label, tooltip, description, validate, digitalAddressTypes},
+  componentDefinition: {
+    key: name,
+    label,
+    tooltip,
+    description,
+    validate,
+    digitalAddressTypes,
+    faqItems = [],
+  },
 }) => {
   const {getFieldMeta} = useFormikContext<FormValues>();
   const id = useId();
@@ -94,6 +103,7 @@ export const FormioCustomerProfile: React.FC<FormioCustomerProfileProps> = ({
       )}
       <HelpText id={descriptionId}>{description}</HelpText>
       {fieldError && errorMessageId && <ValidationErrors id={errorMessageId} error={fieldError} />}
+      <FAQItems items={faqItems} />
     </Fieldset>
   );
 };

--- a/src/registry/date/index.stories.tsx
+++ b/src/registry/date/index.stories.tsx
@@ -59,6 +59,37 @@ export const MinimalConfigurationDatePicker: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'date',
+      key: 'my.date',
+      label: 'Your date',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+      openForms: {translations: {}, widget: 'inputGroup'},
+    } satisfies DateComponentSchema,
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          date: '',
+        },
+      },
+    },
+  },
+};
+
 export const WithTooltipInputGroup: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/date/index.tsx
+++ b/src/registry/date/index.tsx
@@ -15,7 +15,7 @@ export interface FormioDateProps {
 }
 
 export const FormioDate: React.FC<FormioDateProps> = ({componentDefinition}) => {
-  const {key, label, tooltip, description, validate, openForms, datePicker, disabled} =
+  const {key, label, tooltip, description, validate, openForms, datePicker, disabled, faqItems} =
     componentDefinition;
 
   const parsedMax = datePicker?.maxDate ? parseDate(datePicker.maxDate) : null;
@@ -24,7 +24,7 @@ export const FormioDate: React.FC<FormioDateProps> = ({componentDefinition}) => 
 
   const sharedProps: Pick<
     React.ComponentProps<typeof DateField>,
-    'name' | 'label' | 'description' | 'tooltip' | 'isRequired' | 'isReadOnly'
+    'name' | 'label' | 'description' | 'tooltip' | 'isRequired' | 'isReadOnly' | 'faqItems'
   > = {
     name: key,
     label,
@@ -32,6 +32,7 @@ export const FormioDate: React.FC<FormioDateProps> = ({componentDefinition}) => 
     tooltip,
     isRequired: validate?.required,
     isReadOnly: disabled,
+    faqItems,
   };
 
   return componentDefinition.multiple ? (

--- a/src/registry/datetime/index.tsx
+++ b/src/registry/datetime/index.tsx
@@ -15,11 +15,12 @@ export interface FormioDateTimeProps {
 }
 
 export const FormioDateTime: React.FC<FormioDateTimeProps> = ({componentDefinition}) => {
-  const {key, label, tooltip, description, validate, datePicker, disabled} = componentDefinition;
+  const {key, label, tooltip, description, validate, datePicker, disabled, faqItems} =
+    componentDefinition;
 
   const sharedProps: Pick<
     React.ComponentProps<typeof DateTimeField>,
-    'name' | 'label' | 'description' | 'tooltip' | 'isRequired' | 'isReadOnly'
+    'name' | 'label' | 'description' | 'tooltip' | 'isRequired' | 'isReadOnly' | 'faqItems'
   > = {
     name: key,
     label,
@@ -27,6 +28,7 @@ export const FormioDateTime: React.FC<FormioDateTimeProps> = ({componentDefiniti
     tooltip,
     isRequired: validate?.required,
     isReadOnly: disabled,
+    faqItems,
   };
 
   // Note: setting a max and min date in the form builder sets a value without the seconds in the

--- a/src/registry/editgrid/index.stories.ts
+++ b/src/registry/editgrid/index.stories.ts
@@ -79,6 +79,44 @@ export const MinimalConfiguration: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'editgrid',
+      key: 'editgrid',
+      label: 'Repeating group',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+      disableAddingRemovingRows: false,
+      groupLabel: 'Nested item',
+      components: [
+        {
+          id: 'component2',
+          type: 'textfield',
+          key: 'my.textfield',
+          label: 'A simple textfield',
+        },
+      ],
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        editgrid: [{my: {textfield: ''}}],
+      },
+    },
+  },
+};
+
 export const WithTooltip: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/editgrid/index.tsx
+++ b/src/registry/editgrid/index.tsx
@@ -205,6 +205,7 @@ export const FormioEditGrid: React.FC<EditGridProps> = ({
     hideLabel,
     tooltip,
     description,
+    faqItems,
     validate,
     disableAddingRemovingRows,
     groupLabel,
@@ -263,6 +264,7 @@ export const FormioEditGrid: React.FC<EditGridProps> = ({
       isRequired={validate?.required}
       description={description}
       enableIsolation
+      faqItems={faqItems}
       getItemHeading={(_, index: number) => (groupLabel ? `${groupLabel} ${index + 1}` : undefined)}
       getItemBody={(_, index: number, {expanded}) => (
         <ItemBody

--- a/src/registry/email/index.stories.tsx
+++ b/src/registry/email/index.stories.tsx
@@ -56,6 +56,34 @@ export const WithTooltip: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'email',
+      key: 'email',
+      label: 'Your email',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        email: '',
+      },
+    },
+  },
+};
+
 export const WithAutoComplete: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/email/index.tsx
+++ b/src/registry/email/index.tsx
@@ -24,17 +24,19 @@ export const FormioEmail: React.FC<FormioEmailProps> = ({componentDefinition}) =
     validate,
     autocomplete,
     openForms = {translations: {}},
+    faqItems,
   } = componentDefinition;
   const prefixedKey = useFieldConfig(key);
   const sharedProps: Pick<
     React.ComponentProps<typeof TextField>,
-    'name' | 'label' | 'description' | 'tooltip' | 'isRequired'
+    'name' | 'label' | 'description' | 'tooltip' | 'isRequired' | 'faqItems'
   > = {
     name: key,
     label,
     description,
     tooltip,
     isRequired: validate?.required,
+    faqItems,
   };
 
   const isVerificationRequired = openForms.requireVerification ?? false;

--- a/src/registry/fieldset/index.stories.ts
+++ b/src/registry/fieldset/index.stories.ts
@@ -79,6 +79,45 @@ export const WithTooltip: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'fieldset',
+      key: 'fieldset',
+      label: 'Fieldset label',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+      hideHeader: false,
+      components: [
+        {
+          id: 'component2',
+          type: 'textfield',
+          key: 'my.textfield',
+          label: 'A simple textfield',
+        },
+      ],
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          textfield: '',
+        },
+      },
+    },
+  },
+};
+
 export const WithoutLabel: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/fieldset/index.tsx
+++ b/src/registry/fieldset/index.tsx
@@ -2,6 +2,7 @@ import type {FieldsetComponentSchema} from '@open-formulieren/types';
 
 import FormFieldContainer from '@/components/FormFieldContainer';
 import type {FormioComponentProps} from '@/components/FormioComponent';
+import FAQItems from '@/components/forms/FAQItems';
 import Fieldset from '@/components/forms/Fieldset';
 import Tooltip from '@/components/forms/Tooltip';
 import type {RegistryEntry} from '@/registry/types';
@@ -16,7 +17,7 @@ export interface FieldsetProps {
 }
 
 export const FormioFieldset: React.FC<FieldsetProps> = ({
-  componentDefinition: {components, hideHeader = false, label, tooltip},
+  componentDefinition: {components, hideHeader = false, label, tooltip, faqItems = []},
   renderNested: FormioComponent,
 }) => {
   return (
@@ -35,6 +36,8 @@ export const FormioFieldset: React.FC<FieldsetProps> = ({
           <FormioComponent key={nestedDefinition.id} componentDefinition={nestedDefinition} />
         ))}
       </FormFieldContainer>
+
+      <FAQItems items={faqItems} />
     </Fieldset>
   );
 };

--- a/src/registry/file/File.tsx
+++ b/src/registry/file/File.tsx
@@ -5,6 +5,7 @@ import {FieldArray, useFormikContext} from 'formik';
 import type {ArrayHelpers, FormikErrors} from 'formik';
 import {useId} from 'react';
 
+import FAQItems from '@/components/forms/FAQItems';
 import HelpText from '@/components/forms/HelpText';
 import Label from '@/components/forms/Label';
 import Tooltip from '@/components/forms/Tooltip';
@@ -54,6 +55,7 @@ const Inner: React.FC<InnerProps> = ({componentDefinition, arrayHelpers}) => {
     fileMaxSize,
     file: {type},
     validate = {},
+    faqItems = [],
   } = componentDefinition;
   const name = useFieldConfig(key);
   const {required: isRequired = false} = validate;
@@ -144,6 +146,8 @@ const Inner: React.FC<InnerProps> = ({componentDefinition, arrayHelpers}) => {
             <ValidationErrors error={fieldError} id={errorMessageId} />
           </div>
         )}
+
+        <FAQItems items={faqItems} />
       </div>
     </FormField>
   );

--- a/src/registry/file/index.stories.tsx
+++ b/src/registry/file/index.stories.tsx
@@ -58,6 +58,37 @@ export const MinimalConfiguration: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      ...getFileConfiguration(['application/pdf', 'application/msword']),
+      id: 'component1',
+      type: 'file',
+      key: 'my.file',
+      label: 'Your file',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+    } satisfies FileComponentSchema,
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          file: [] satisfies FormikFileUpload[],
+        },
+      },
+    },
+  },
+};
+
 export const WithDescriptionAndTooltip: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/iban/index.stories.tsx
+++ b/src/registry/iban/index.stories.tsx
@@ -37,6 +37,36 @@ export const MinimalConfiguration: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'iban',
+      key: 'my.iban',
+      label: 'An IBAN',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+    } satisfies IbanComponentSchema,
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          iban: '',
+        },
+      },
+    },
+  },
+};
+
 export const WithTooltip: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/iban/index.tsx
+++ b/src/registry/iban/index.tsx
@@ -14,16 +14,17 @@ export interface FormioIBANProps {
 }
 
 export const FormioIBAN: React.FC<FormioIBANProps> = ({componentDefinition}) => {
-  const {key, label, tooltip, description, validate} = componentDefinition;
+  const {key, label, tooltip, description, validate, faqItems} = componentDefinition;
   const sharedProps: Pick<
     React.ComponentProps<typeof TextField>,
-    'name' | 'label' | 'description' | 'tooltip' | 'isRequired'
+    'name' | 'label' | 'description' | 'tooltip' | 'isRequired' | 'faqItems'
   > = {
     name: key,
     label,
     description,
     tooltip,
     isRequired: validate?.required,
+    faqItems,
   };
 
   return componentDefinition.multiple ? (

--- a/src/registry/licenseplate/index.stories.tsx
+++ b/src/registry/licenseplate/index.stories.tsx
@@ -38,6 +38,38 @@ export const MinimalConfiguration: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  ...MinimalConfiguration,
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'licenseplate',
+      key: 'license.plate',
+      label: 'License plate',
+      validate: {pattern: '^[a-zA-Z0-9]{1,3}\\-[a-zA-Z0-9]{1,3}\\-[a-zA-Z0-9]{1,3}$'},
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        license: {
+          plate: '',
+        },
+      },
+    },
+  },
+};
+
 export const WithTooltip: Story = {
   ...MinimalConfiguration,
   args: {

--- a/src/registry/licenseplate/index.tsx
+++ b/src/registry/licenseplate/index.tsx
@@ -14,16 +14,17 @@ export interface FormioLicensePlateProps {
 }
 
 export const FormioLicensePlate: React.FC<FormioLicensePlateProps> = ({componentDefinition}) => {
-  const {key, label, tooltip, description, validate} = componentDefinition;
+  const {key, label, tooltip, description, validate, faqItems} = componentDefinition;
   const sharedProps: Pick<
     React.ComponentProps<typeof TextField>,
-    'name' | 'label' | 'description' | 'tooltip' | 'isRequired' | 'isReadOnly'
+    'name' | 'label' | 'description' | 'tooltip' | 'isRequired' | 'isReadOnly' | 'faqItems'
   > = {
     name: key,
     label,
     description,
     tooltip,
     isRequired: validate?.required,
+    faqItems,
   };
   return componentDefinition.multiple ? (
     <MultiField<string>

--- a/src/registry/map/index.stories.tsx
+++ b/src/registry/map/index.stories.tsx
@@ -40,6 +40,34 @@ export const MinimalConfiguration: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'map',
+      type: 'map',
+      key: 'my.map',
+      label: 'A map',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        map: null,
+      },
+    },
+  },
+};
+
 export const WithTooltip: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/map/index.tsx
+++ b/src/registry/map/index.tsx
@@ -5,6 +5,7 @@ import {useField, useFormikContext} from 'formik';
 import React, {useId} from 'react';
 
 import {HelpText, Label, ValidationErrors} from '@/components/forms';
+import FAQItems from '@/components/forms/FAQItems';
 import Tooltip from '@/components/forms/Tooltip';
 import LeafletMap from '@/components/map';
 import {useFieldConfig, useFieldError} from '@/hooks';
@@ -32,6 +33,7 @@ export const FormioMap: React.FC<FormioMapProps> = ({componentDefinition}) => {
     interactions = DEFAULT_INTERACTIONS,
     overlays,
     validate,
+    faqItems = [],
   } = componentDefinition;
   const name = useFieldConfig(key);
   const id = useId();
@@ -84,6 +86,7 @@ export const FormioMap: React.FC<FormioMapProps> = ({componentDefinition}) => {
 
       <HelpText>{description}</HelpText>
       {touched && errorMessageId && <ValidationErrors error={error} id={errorMessageId} />}
+      <FAQItems items={faqItems} />
     </FormField>
   );
 };

--- a/src/registry/number/index.stories.tsx
+++ b/src/registry/number/index.stories.tsx
@@ -71,6 +71,34 @@ export const MinimalConfigurationWithEnglishLocale: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'number',
+      type: 'number',
+      key: 'number',
+      label: 'Number',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        number: null,
+      },
+    },
+  },
+};
+
 export const WithTooltip: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/number/index.tsx
+++ b/src/registry/number/index.tsx
@@ -23,6 +23,7 @@ export const FormioNumberField: React.FC<FormioNumberFieldProps> = ({
     allowNegative,
     prefix,
     suffix,
+    faqItems,
   },
 }) => {
   return (
@@ -36,6 +37,7 @@ export const FormioNumberField: React.FC<FormioNumberFieldProps> = ({
       allowNegative={allowNegative}
       prefix={prefix}
       suffix={suffix}
+      faqItems={faqItems}
     />
   );
 };

--- a/src/registry/partners/index.stories.tsx
+++ b/src/registry/partners/index.stories.tsx
@@ -44,6 +44,27 @@ type Story = StoryObj<typeof FormioPartnersField>;
 
 export const MinimalConfiguration: Story = {};
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'partners',
+      type: 'partners',
+      key: 'partners',
+      label: 'Partners',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+    },
+  },
+};
+
 export const WithTooltipAndDescription: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/partners/index.tsx
+++ b/src/registry/partners/index.tsx
@@ -5,6 +5,7 @@ import {FormattedMessage} from 'react-intl';
 
 import {PrimaryActionButton, SecondaryActionButton} from '@/components/Button';
 import FormFieldContainer from '@/components/FormFieldContainer';
+import FAQItems from '@/components/forms/FAQItems';
 import Fieldset from '@/components/forms/Fieldset';
 import HelpText from '@/components/forms/HelpText';
 import Tooltip from '@/components/forms/Tooltip';
@@ -25,7 +26,7 @@ export interface FormioPartnersFieldProps {
 }
 
 export const FormioPartnersField: React.FC<FormioPartnersFieldProps> = ({
-  componentDefinition: {key, label, description, tooltip},
+  componentDefinition: {key, label, description, tooltip, faqItems = []},
 }) => {
   const {setFieldValue, getFieldProps} = useFormikContext();
   const {value: partners} = getFieldProps<ManuallyAddedPartnerDetails[] | PartnerDetails[]>(key);
@@ -85,6 +86,7 @@ export const FormioPartnersField: React.FC<FormioPartnersFieldProps> = ({
       )}
 
       <HelpText>{description}</HelpText>
+      <FAQItems items={faqItems} />
     </Fieldset>
   );
 };

--- a/src/registry/phoneNumber/index.stories.tsx
+++ b/src/registry/phoneNumber/index.stories.tsx
@@ -37,6 +37,34 @@ export const MinimalConfiguration: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'phoneNumber',
+      key: 'phoneNumber',
+      label: 'A simple phone number',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        phoneNumber: '',
+      },
+    },
+  },
+};
+
 export const WithTooltip: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/phoneNumber/index.tsx
+++ b/src/registry/phoneNumber/index.tsx
@@ -22,16 +22,17 @@ export interface PhoneNumberFieldProps {
  * validators.
  */
 export const PhoneNumberField: React.FC<PhoneNumberFieldProps> = ({componentDefinition}) => {
-  const {key, label, tooltip, description, validate, autocomplete} = componentDefinition;
+  const {key, label, tooltip, description, validate, autocomplete, faqItems} = componentDefinition;
   const sharedProps: Pick<
     React.ComponentProps<typeof TextField>,
-    'name' | 'label' | 'description' | 'tooltip' | 'isRequired' | 'isReadOnly'
+    'name' | 'label' | 'description' | 'tooltip' | 'isRequired' | 'isReadOnly' | 'faqItems'
   > = {
     name: key,
     label,
     description,
     tooltip,
     isRequired: validate?.required,
+    faqItems,
   };
   return componentDefinition.multiple ? (
     <MultiField<string>

--- a/src/registry/postcode/index.stories.tsx
+++ b/src/registry/postcode/index.stories.tsx
@@ -40,6 +40,39 @@ export const MinimalConfiguration: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'postcode',
+      key: 'my.postcode',
+      label: 'A simple postcode field',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+      validate: {
+        pattern: '^[1-9][0-9]{3} ?(?!sa|sd|ss|SA|SD|SS)[a-zA-Z]{2}$',
+      },
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          postcode: '',
+        },
+      },
+    },
+  },
+};
+
 export const WithTooltip: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/postcode/index.tsx
+++ b/src/registry/postcode/index.tsx
@@ -14,10 +14,10 @@ export interface FormioPostCodeProps {
 }
 
 export const PostCodeField: React.FC<FormioPostCodeProps> = ({componentDefinition}) => {
-  const {key, label, tooltip, description, validate, disabled} = componentDefinition;
+  const {key, label, tooltip, description, validate, disabled, faqItems} = componentDefinition;
   const sharedProps: Pick<
     React.ComponentProps<typeof TextField>,
-    'name' | 'label' | 'description' | 'tooltip' | 'isRequired' | 'isReadOnly'
+    'name' | 'label' | 'description' | 'tooltip' | 'isRequired' | 'isReadOnly' | 'faqItems'
   > = {
     name: key,
     label,
@@ -25,6 +25,7 @@ export const PostCodeField: React.FC<FormioPostCodeProps> = ({componentDefinitio
     tooltip,
     isRequired: validate?.required,
     isReadOnly: disabled,
+    faqItems,
   };
   return componentDefinition.multiple ? (
     <MultiField<string>

--- a/src/registry/radio/index.stories.tsx
+++ b/src/registry/radio/index.stories.tsx
@@ -56,6 +56,48 @@ export const MinimalConfiguration: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'radio',
+      key: 'my.radio',
+      label: 'A radio choice',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+      values: [
+        {
+          value: 'terra',
+          label: 'Terra',
+        },
+        {
+          value: 'ziggy',
+          label: 'Ziggy',
+        },
+      ],
+      defaultValue: null,
+      ...extensionBoilerplate,
+    } satisfies RadioComponentSchema,
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          radio: null,
+        },
+      },
+    },
+  },
+};
+
 export const WithTooltip: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/radio/index.tsx
+++ b/src/registry/radio/index.tsx
@@ -13,7 +13,15 @@ export interface FormioRadioFieldProps {
 }
 
 export const FormioRadioField: React.FC<FormioRadioFieldProps> = ({componentDefinition}) => {
-  const {key, label, tooltip, description, validate = {}, values} = componentDefinition;
+  const {
+    key,
+    label,
+    tooltip,
+    description,
+    validate = {},
+    faqItems = [],
+    values,
+  } = componentDefinition;
   const {required = false} = validate;
   return (
     <RadioField
@@ -23,6 +31,7 @@ export const FormioRadioField: React.FC<FormioRadioFieldProps> = ({componentDefi
       description={description}
       isRequired={required}
       options={values}
+      faqItems={faqItems}
     />
   );
 };

--- a/src/registry/select/index.stories.tsx
+++ b/src/registry/select/index.stories.tsx
@@ -73,6 +73,43 @@ export const Multiple: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'select',
+      key: 'my.select',
+      label: 'A simple select',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+      data: {
+        values: [
+          {value: '1', label: 'First'},
+          {value: '2', label: 'Second'},
+        ],
+      },
+      openForms: {translations: {}, dataSrc: 'manual'},
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          select: '',
+        },
+      },
+    },
+  },
+};
+
 export const WithTooltip: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/select/index.tsx
+++ b/src/registry/select/index.tsx
@@ -21,6 +21,7 @@ export const FormioSelect: React.FC<FormioSelectProps> = ({componentDefinition})
     data: {values: options},
     multiple,
     validate,
+    faqItems,
   } = componentDefinition;
   return (
     <Select
@@ -32,6 +33,7 @@ export const FormioSelect: React.FC<FormioSelectProps> = ({componentDefinition})
       description={description}
       isRequired={validate?.required}
       noOptionSelectedValue=""
+      faqItems={faqItems}
     />
   );
 };

--- a/src/registry/selectboxes/index.stories.tsx
+++ b/src/registry/selectboxes/index.stories.tsx
@@ -59,6 +59,51 @@ export const MinimalConfiguration: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'selectboxes',
+      key: 'my.selectboxes',
+      label: 'Selecboxes choices',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+      values: [
+        {
+          value: 'terra',
+          label: 'Terra',
+        },
+        {
+          value: 'ziggy',
+          label: 'Ziggy',
+        },
+      ],
+      defaultValue: {terra: true, ziggy: true},
+      ...extensionBoilerplate,
+    } satisfies SelectboxesComponentSchema,
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          selectboxes: {
+            terra: true,
+            ziggy: true,
+          },
+        },
+      },
+    },
+  },
+};
+
 export const WithTooltip: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/selectboxes/index.tsx
+++ b/src/registry/selectboxes/index.tsx
@@ -5,6 +5,7 @@ import {useField, useFormikContext} from 'formik';
 import {useEffect, useId, useMemo, useRef} from 'react';
 
 import Checkbox from '@/components/forms/Checkbox';
+import FAQItems from '@/components/forms/FAQItems';
 import HelpText from '@/components/forms/HelpText';
 import {LabelContent} from '@/components/forms/Label';
 import Tooltip from '@/components/forms/Tooltip';
@@ -26,7 +27,15 @@ export const FormioSelectboxes: React.FC<FormioSelectboxesProps> = ({
   componentDefinition,
   getRegistryEntry,
 }) => {
-  const {key, label, tooltip, description, validate = {}, values: options} = componentDefinition;
+  const {
+    key,
+    label,
+    tooltip,
+    description,
+    validate = {},
+    values: options,
+    faqItems = [],
+  } = componentDefinition;
   const {required = false, maxSelectedCount} = validate;
   const {getFieldProps, getFieldMeta, validateField} = useFormikContext();
   const [{value: selectboxesState = {}}, {error = ''}, {setValue}] = useField<
@@ -181,6 +190,7 @@ export const FormioSelectboxes: React.FC<FormioSelectboxesProps> = ({
 
       <HelpText id={descriptionid}>{description}</HelpText>
       {touched && errorMessageId && <ValidationErrors error={error} id={errorMessageId} />}
+      <FAQItems items={faqItems} />
     </Fieldset>
   );
 };

--- a/src/registry/signature/index.stories.tsx
+++ b/src/registry/signature/index.stories.tsx
@@ -44,6 +44,35 @@ export const MinimalConfiguration: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'signature',
+      type: 'signature',
+      key: 'signature',
+      label: 'Signature',
+      footer: 'Awesome footer!',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        signature: '',
+      },
+    },
+  },
+};
+
 export const WithTooltipDescriptionAndFooter: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/signature/index.tsx
+++ b/src/registry/signature/index.tsx
@@ -5,6 +5,7 @@ import {useId, useLayoutEffect, useRef} from 'react';
 import {useIntl} from 'react-intl';
 import SignatureCanvas from 'react-signature-canvas';
 
+import FAQItems from '@/components/forms/FAQItems';
 import HelpText from '@/components/forms/HelpText';
 import Label from '@/components/forms/Label';
 import Tooltip from '@/components/forms/Tooltip';
@@ -35,7 +36,15 @@ export interface FormioSignatureFieldProps {
  * It includes a button with which the entire canvas can be cleared.
  */
 export const FormioSignatureField: React.FC<FormioSignatureFieldProps> = ({
-  componentDefinition: {key: name, label, description, tooltip, validate = {}, footer},
+  componentDefinition: {
+    key: name,
+    label,
+    description,
+    tooltip,
+    validate = {},
+    footer,
+    faqItems = [],
+  },
 }) => {
   name = useFieldConfig(name);
   const intl = useIntl();
@@ -144,6 +153,7 @@ export const FormioSignatureField: React.FC<FormioSignatureFieldProps> = ({
       </div>
       <HelpText>{description}</HelpText>
       {touched && errorMessageId && <ValidationErrors error={error} id={errorMessageId} />}
+      <FAQItems items={faqItems} />
     </FormField>
   );
 };

--- a/src/registry/textarea/index.stories.tsx
+++ b/src/registry/textarea/index.stories.tsx
@@ -58,6 +58,37 @@ export const WithPlaceholder: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'textarea',
+      key: 'my.textarea',
+      label: 'A simple textarea',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+      autoExpand: false,
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          textarea: '',
+        },
+      },
+    },
+  },
+};
+
 export const WithTooltip: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/textarea/index.tsx
+++ b/src/registry/textarea/index.tsx
@@ -25,10 +25,11 @@ export const FormioTextarea: React.FC<FormioTextareaProps> = ({componentDefiniti
     autocomplete,
     rows,
     disabled,
+    faqItems,
   } = componentDefinition;
   const sharedProps: Pick<
     React.ComponentProps<typeof Textarea>,
-    'name' | 'label' | 'description' | 'tooltip' | 'isRequired' | 'isReadOnly'
+    'name' | 'label' | 'description' | 'tooltip' | 'isRequired' | 'isReadOnly' | 'faqItems'
   > = {
     name: key,
     label,
@@ -36,6 +37,7 @@ export const FormioTextarea: React.FC<FormioTextareaProps> = ({componentDefiniti
     tooltip,
     isRequired: validate?.required,
     isReadOnly: disabled,
+    faqItems,
   };
 
   return componentDefinition.multiple ? (

--- a/src/registry/textfield/index.stories.tsx
+++ b/src/registry/textfield/index.stories.tsx
@@ -57,6 +57,36 @@ export const WithPlaceholder: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      id: 'component1',
+      type: 'textfield',
+      key: 'my.textfield',
+      label: 'A simple textfield',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          textfield: '',
+        },
+      },
+    },
+  },
+};
+
 export const WithTooltip: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/textfield/index.tsx
+++ b/src/registry/textfield/index.tsx
@@ -24,11 +24,12 @@ export const FormioTextField: React.FC<FormioTextFieldProps> = ({componentDefini
     validate,
     disabled,
     showCharCount,
+    faqItems,
   } = componentDefinition;
 
   const sharedProps: Pick<
     React.ComponentProps<typeof TextField>,
-    'name' | 'label' | 'description' | 'tooltip' | 'isRequired' | 'isReadOnly'
+    'name' | 'label' | 'description' | 'tooltip' | 'isRequired' | 'isReadOnly' | 'faqItems'
   > = {
     name: key,
     label,
@@ -36,6 +37,7 @@ export const FormioTextField: React.FC<FormioTextFieldProps> = ({componentDefini
     tooltip,
     isRequired: validate?.required,
     isReadOnly: disabled,
+    faqItems,
   };
   return componentDefinition.multiple ? (
     <MultiField<string>

--- a/src/registry/time/index.stories.tsx
+++ b/src/registry/time/index.stories.tsx
@@ -37,6 +37,36 @@ export const MinimalConfiguration: Story = {
   },
 };
 
+export const WithFAQItems: Story = {
+  args: {
+    componentDefinition: {
+      type: 'time',
+      key: 'my.time',
+      id: 'timefield',
+      label: 'timefield',
+      faqItems: [
+        {
+          label: 'How do I fill in this field?',
+          content: 'The values required to fill out this field can be retrieved from XYZ.',
+        },
+        {
+          label: 'Is this field applicable to me?',
+          content: 'This field is applicable if you are XYZ.',
+        },
+      ],
+    },
+  },
+  parameters: {
+    formik: {
+      initialValues: {
+        my: {
+          time: '',
+        },
+      },
+    },
+  },
+};
+
 export const WithTooltip: Story = {
   args: {
     componentDefinition: {

--- a/src/registry/time/index.tsx
+++ b/src/registry/time/index.tsx
@@ -14,10 +14,10 @@ export interface TimeFieldProps {
 }
 
 export const TimeField: React.FC<TimeFieldProps> = ({componentDefinition}) => {
-  const {key, label, description, tooltip, validate, disabled} = componentDefinition;
+  const {key, label, description, tooltip, validate, disabled, faqItems} = componentDefinition;
   const sharedProps: Pick<
     React.ComponentProps<typeof TextField>,
-    'name' | 'label' | 'description' | 'tooltip' | 'isRequired' | 'isReadOnly'
+    'name' | 'label' | 'description' | 'tooltip' | 'isRequired' | 'isReadOnly' | 'faqItems'
   > = {
     name: key,
     label,
@@ -25,6 +25,7 @@ export const TimeField: React.FC<TimeFieldProps> = ({componentDefinition}) => {
     tooltip,
     isRequired: validate?.required,
     isReadOnly: disabled,
+    faqItems,
   };
   return componentDefinition.multiple ? (
     <MultiField<string>


### PR DESCRIPTION
Closes the following bullet point, [from this ticket](https://github.com/open-formulieren/open-forms/issues/6315#issue-4523952977):

> Implement tool tip per field following the design in the front end

This branch was branched off from `open-formulieren/feature/6315-modal-sheet` as it depends on the updated Modal component.

TODO:

- [x] Update the pinned types version (to use the `FAQItem` types)