### PR TITLE
Fix value display for times without seconds

### DIFF
--- a/src/registry/time/ValueDisplay.tsx
+++ b/src/registry/time/ValueDisplay.tsx
@@ -16,14 +16,14 @@ const formatTime = (timeValue: string): React.ReactNode => {
   let time = new Date(timeValue);
 
   if (isNaN(Number(time))) {
-    const [hours, minutes, seconds] = timeValue.split(':');
+    const [hours, minutes, seconds = '00'] = timeValue.split(':');
     time = new Date();
     time.setHours(parseInt(hours));
     time.setMinutes(parseInt(minutes));
     time.setSeconds(parseInt(seconds));
   }
 
-  return <FormattedTime value={time} format="short" />;
+  return <FormattedTime value={time} />;
 };
 
 const ValueDisplay: React.FC<ValueDisplayProps> = ({

--- a/src/registry/time/index.stories.tsx
+++ b/src/registry/time/index.stories.tsx
@@ -497,3 +497,17 @@ export const MultiValueDisplay: ValueDisplayStory = {
     value: ['12:00:00', '00:00:00'],
   },
 };
+
+export const ValueDisplayNoSecondsPart: ValueDisplayStory = {
+  ...BaseValueDisplayStory,
+  args: {
+    componentDefinition: {
+      type: 'time',
+      key: 'time',
+      id: 'timefield',
+      label: 'timefield',
+      multiple: false,
+    } satisfies TimeComponentSchema,
+    value: '15:30',
+  },
+};


### PR DESCRIPTION
Closes open-formulieren/open-forms#6356

The native time input (with minute-precision) passes the value as just HH:mm and omits the seconds part - which is valid according to the spec. Our time parts parsing code didn't take this possibility into account when preparing the value for display.