### PR TITLE
Ensure the first component with validation error(s) is scrolled into view

### DIFF
--- a/src/components/FormioForm.stories.tsx
+++ b/src/components/FormioForm.stories.tsx
@@ -834,3 +834,33 @@ export const ValidationForMultipleDateComponents: Story = {
     expect(dateRequired).toHaveAttribute('aria-invalid', 'true');
   },
 };
+
+export const ScrollsFirstErrorIntoView: Story = {
+  args: {
+    components: [...Array(15).keys()].map(i => ({
+      id: `component-${i}`,
+      type: 'textfield',
+      key: `field-${i}`,
+      label: `Field ${i}`,
+      validate: {
+        required: false,
+        maxLength: 5,
+      },
+    })),
+  },
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.type(canvas.getByLabelText('Field 0'), 'value too long!');
+    await userEvent.type(canvas.getByLabelText('Field 10'), 'value too long!');
+
+    await userEvent.click(canvas.getByRole('button', {name: 'Submit'}));
+
+    const errors = await canvas.findAllByText('There are too many characters provided.');
+    expect(errors).toHaveLength(2);
+    for (const errorNode of errors) {
+      expect(errorNode).toBeVisible();
+    }
+  },
+};

--- a/src/components/FormioForm.tsx
+++ b/src/components/FormioForm.tsx
@@ -245,8 +245,18 @@ export type InnerFormioFormProps = Pick<FormioFormProps, 'components' | 'id' | '
 const InnerFormioForm = forwardRef<FormStateRef, InnerFormioFormProps>(
   ({components, validatePluginCallback, id, onValidationSchemaChange, children}, ref) => {
     const intl = useIntl();
-    const {values, setValues, errors, setErrors, setTouched, initialValues} =
-      useFormikContext<JSONObject>();
+    const {
+      values,
+      setValues,
+      errors,
+      setErrors,
+      setTouched,
+      initialValues,
+      isValidating,
+      submitCount,
+    } = useFormikContext<JSONObject>();
+    const formContainer = useRef<HTMLFormElement | null>(null);
+    const lastHandledSubmit = useRef(0);
 
     useImperativeHandle(
       ref,
@@ -340,8 +350,35 @@ const InnerFormioForm = forwardRef<FormStateRef, InnerFormioFormProps>(
       }
     }, [errors, setErrors]);
 
+    // ensure that the first error in the form is scrolled into view, if any.
+    // Formik updates the submitCount on every submit attempt and runs validation. By
+    // doing the scroll effect after explicit submit, we avoid scrolling the page when
+    // the user is doing *other* actions.
+    const hasErrors = Object.keys(errors).length > 0;
+    useEffect(() => {
+      if (submitCount === 0) return;
+      if (isValidating) return;
+      if (lastHandledSubmit.current === submitCount) return;
+      if (!hasErrors) return;
+      lastHandledSubmit.current = submitCount;
+
+      // the query selector is the easiest way to find the first element, rather than
+      // trying to determine the order from the component definition or error messages
+      // object structure...
+      const firstErrorMessage = formContainer.current?.querySelector(
+        '.utrecht-form-field--invalid, .openforms-fieldset--invalid'
+      );
+      if (!firstErrorMessage) return;
+      const reqId = requestAnimationFrame(() => {
+        firstErrorMessage.scrollIntoView({behavior: 'smooth'});
+      });
+      return () => {
+        window.cancelAnimationFrame(reqId);
+      };
+    }, [submitCount, isValidating, hasErrors]);
+
     return (
-      <Form noValidate id={id}>
+      <Form noValidate id={id} ref={formContainer}>
         <FormFieldContainer>
           {componentsToRender.map((definition, index) => (
             <FormioComponent key={`${definition.id || index}`} componentDefinition={definition} />


### PR DESCRIPTION
Closes open-formulieren/open-forms#6375

We use the formik submitCount to determine if we need to trigger a scroll action, to ensure this only happens after the user submits the form. We can't tap into Formik's validation chain, as the submit action triggers Formik validation, and only when the form is valid, onSubmit will be called, which is too late.

This mechanism queries the children of the form container for the first error element, based on the NL DS class names. We can't really test this easily, but it's expected the Chromatic snapshots will capture the scroll position properly. That's why the story uses 50 form fields.