### PR TITLE
Limit datepicker date to max date from validation

### DIFF
--- a/src/components/forms/DateField/DatePicker/DatePicker.tsx
+++ b/src/components/forms/DateField/DatePicker/DatePicker.tsx
@@ -12,7 +12,7 @@ import Tooltip from '@/components/forms/Tooltip';
 
 import {useDateLocaleMeta} from '../hooks';
 import {PART_PLACEHOLDERS} from '../messages';
-import {parseDate} from '../utils';
+import {getBestInitialDate, parseDate} from '../utils';
 import './DatePicker.scss';
 
 interface DatePickerFieldProps {
@@ -181,7 +181,7 @@ const DatePickerField: React.FC<DatePickerFieldProps> = ({
                 await validateField(name);
                 setIsOpen(false);
               }}
-              currentDate={currentDate ?? undefined}
+              currentDate={currentDate ?? getBestInitialDate(minDate, maxDate)}
               minDate={minDate}
               maxDate={maxDate}
               displayWeekend={displayWeekend}

--- a/src/components/forms/DateField/utils.ts
+++ b/src/components/forms/DateField/utils.ts
@@ -73,3 +73,38 @@ export const getDateLocaleMeta = (locale: string): LocaleMeta => {
     .filter(type => type === 'year' || type === 'month' || type === 'day');
   return {partsOrder, separator};
 };
+
+/**
+ * Determine the "best" initial date for the date picker.
+ *
+ * Given the (optional) minimum and maximum bounds, pick the bound that should lead
+ * to the least amount of clicks for the user to get to a valid date. There are a
+ * number of cases to consider here that prevent use from using date-fns `min` helper:
+ *
+ * - for a max date in the past, use the max date so the user doesn't have to skip over
+ *   all days between the past max date & now
+ * - for a min date in the future, a similar case applies
+ * - when both min and max date are specified and today falls within the interval -
+ *   don't use any of the bounds, as the date picker defaults to the current date
+ */
+export const getBestInitialDate = (
+  minDate: Date | undefined,
+  maxDate: Date | undefined
+): Date | undefined => {
+  // no bounds given -> nothing to decide
+  if (minDate === undefined && maxDate === undefined) return undefined;
+
+  const now = new Date();
+  // both bounds given and now falls within the interval -> nothing to decide either
+  if (minDate !== undefined && minDate <= now && maxDate !== undefined && now <= maxDate)
+    return undefined;
+
+  // for max date in the past, use the max date as closest moment to 'now'
+  if (maxDate !== undefined && maxDate <= now) return maxDate;
+
+  // for min date in the future, use the min date as closest moment to 'now'
+  if (minDate !== undefined && minDate >= now) return minDate;
+
+  // max date in the future or min date in the past -> nothing to decide
+  return undefined;
+};

--- a/src/components/forms/DateTimeField/DateTimeField.tsx
+++ b/src/components/forms/DateTimeField/DateTimeField.tsx
@@ -16,7 +16,7 @@ import {useFieldConfig, useFieldError} from '@/hooks';
 import './DateTimeField.scss';
 import {useDateLocaleMeta} from './hooks';
 import {PART_PLACEHOLDERS} from './messages';
-import {parseDateTime} from './utils';
+import {getBestInitialDate, parseDateTime} from './utils';
 
 export interface DateTimeFieldProps {
   /**
@@ -245,7 +245,7 @@ const DateTimeField: React.FC<DateTimeFieldProps> = ({
                 } as React.ChangeEvent<HTMLInputElement>;
                 onPartChange(e);
               }}
-              currentDate={currentDateTime ?? undefined}
+              currentDate={currentDateTime ?? getBestInitialDate(minDate, maxDate)}
               minDate={minDate}
               maxDate={maxDate}
             >

--- a/src/components/forms/DateTimeField/utils.ts
+++ b/src/components/forms/DateTimeField/utils.ts
@@ -121,3 +121,38 @@ export const getDateLocaleMeta = (locale: string): LocaleMeta => {
   const is24HourFormat = !parts.find(part => part.type === 'dayPeriod');
   return {datePartsOrder, dateSeparator, timeSeparator, is24HourFormat};
 };
+
+/**
+ * Determine the "best" initial date for the date picker.
+ *
+ * Given the (optional) minimum and maximum bounds, pick the bound that should lead
+ * to the least amount of clicks for the user to get to a valid date. There are a
+ * number of cases to consider here that prevent use from using date-fns `min` helper:
+ *
+ * - for a max date in the past, use the max date so the user doesn't have to skip over
+ *   all days between the past max date & now
+ * - for a min date in the future, a similar case applies
+ * - when both min and max date are specified and today falls within the interval -
+ *   don't use any of the bounds, as the date picker defaults to the current date
+ */
+export const getBestInitialDate = (
+  minDate: Date | undefined,
+  maxDate: Date | undefined
+): Date | undefined => {
+  // no bounds given -> nothing to decide
+  if (minDate === undefined && maxDate === undefined) return undefined;
+
+  const now = new Date();
+  // both bounds given and now falls within the interval -> nothing to decide either
+  if (minDate !== undefined && minDate <= now && maxDate !== undefined && now <= maxDate)
+    return undefined;
+
+  // for max date in the past, use the max date as closest moment to 'now'
+  if (maxDate !== undefined && maxDate <= now) return maxDate;
+
+  // for min date in the future, use the min date as closest moment to 'now'
+  if (minDate !== undefined && minDate >= now) return minDate;
+
+  // max date in the future or min date in the past -> nothing to decide
+  return undefined;
+};

--- a/src/registry/date/index.spec.tsx
+++ b/src/registry/date/index.spec.tsx
@@ -1,0 +1,59 @@
+import type {DateComponentSchema} from '@open-formulieren/types';
+import {IntlProvider} from 'react-intl';
+import {afterEach, beforeEach, expect, test, vi} from 'vitest';
+import {render} from 'vitest-browser-react';
+
+import FormioForm from '@/components/FormioForm';
+import type {FormioFormProps} from '@/components/FormioForm';
+
+type FormProps = Pick<FormioFormProps, 'components' | 'onSubmit' | 'values'>;
+
+const Form: React.FC<FormProps> = props => (
+  <IntlProvider locale="en" messages={{}}>
+    <FormioForm {...props} id="test-form" requiredFieldsWithAsterisk />
+    <button type="submit" form="test-form">
+      Submit
+    </button>
+  </IntlProvider>
+);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test.each([
+  ['', '2020-01-01', 'January 2020'],
+  ['', '2040-01-01', 'July 2026'],
+  ['2010-01-01', '', 'July 2026'],
+  ['2040-01-01', '', 'January 2040'],
+  ['2010-01-01', '2020-01-01', 'January 2020'],
+  ['2040-01-01', '2050-01-01', 'January 2040'],
+  ['2010-01-01', '2050-01-01', 'July 2026'],
+])(
+  'initial date picker date uses closest available option (minDate: %s, maxDate: %s)',
+  async (minDate: string, maxDate: string, needle: string) => {
+    vi.setSystemTime(new Date(2026, 6, 1, 16));
+    const onSubmit = vi.fn();
+    const component: DateComponentSchema = {
+      id: 'date',
+      type: 'date',
+      key: 'date',
+      label: 'Date',
+      openForms: {translations: {}, widget: 'datePicker'},
+      datePicker: {
+        minDate: minDate,
+        maxDate: maxDate,
+      },
+    };
+
+    const screen = await render(<Form components={[component]} onSubmit={onSubmit} />);
+
+    await screen.getByRole('button', {name: 'Toggle calendar'}).click();
+    await expect.element(screen.getByRole('dialog')).toBeVisible();
+    await expect.element(screen.getByText(needle), {timeout: 3000}).toBeVisible();
+  }
+);

--- a/src/registry/datetime/index.spec.tsx
+++ b/src/registry/datetime/index.spec.tsx
@@ -1,0 +1,58 @@
+import type {DateTimeComponentSchema} from '@open-formulieren/types';
+import {IntlProvider} from 'react-intl';
+import {afterEach, beforeEach, expect, test, vi} from 'vitest';
+import {render} from 'vitest-browser-react';
+
+import FormioForm from '@/components/FormioForm';
+import type {FormioFormProps} from '@/components/FormioForm';
+
+type FormProps = Pick<FormioFormProps, 'components' | 'onSubmit' | 'values'>;
+
+const Form: React.FC<FormProps> = props => (
+  <IntlProvider locale="en" messages={{}}>
+    <FormioForm {...props} id="test-form" requiredFieldsWithAsterisk />
+    <button type="submit" form="test-form">
+      Submit
+    </button>
+  </IntlProvider>
+);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test.each([
+  ['', '2020-01-01', 'January 2020'],
+  ['', '2040-01-01', 'July 2026'],
+  ['2010-01-01', '', 'July 2026'],
+  ['2040-01-01', '', 'January 2040'],
+  ['2010-01-01', '2020-01-01', 'January 2020'],
+  ['2040-01-01', '2050-01-01', 'January 2040'],
+  ['2010-01-01', '2050-01-01', 'July 2026'],
+])(
+  'initial date picker date uses closest available option (minDate: %s, maxDate: %s)',
+  async (minDate: string, maxDate: string, needle: string) => {
+    vi.setSystemTime(new Date(2026, 6, 1, 16));
+    const onSubmit = vi.fn();
+    const component: DateTimeComponentSchema = {
+      id: 'datetime',
+      type: 'datetime',
+      key: 'datetime',
+      label: 'Datetime',
+      datePicker: {
+        minDate: minDate,
+        maxDate: maxDate,
+      },
+    };
+
+    const screen = await render(<Form components={[component]} onSubmit={onSubmit} />);
+
+    await screen.getByRole('button', {name: 'Toggle calendar'}).click();
+    await expect.element(screen.getByRole('dialog')).toBeVisible();
+    await expect.element(screen.getByText(needle), {timeout: 3000}).toBeVisible();
+  }
+);


### PR DESCRIPTION
Closes open-formulieren/open-forms#6403

Ensure the users don't need to click tens of times when a maximum date(time) is configured on the date/datetime components.