### PR TITLE
Set up correct defaults for `ul` styling

### DIFF
--- a/src/registry/content/index.stories.tsx
+++ b/src/registry/content/index.stories.tsx
@@ -41,7 +41,18 @@ export const SimpleContent: Story = {
       cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
       proident, sunt in culpa qui officia deserunt mollit anim id
       <a href="https://example.com" target="_blank" rel="external">est laborum</a>.</p>
-      <p>Second paragraph</p>`,
+      <p>Second paragraph</p>
+      <ul>
+        <li>Unordered list</li>
+        <li>
+          With nested items:
+          <ul>
+            <li>Item 1</li>
+            <li>Item 2</li>
+          </ul>
+        </li>
+      </ul>
+      `,
       customClass: '',
     } satisfies ContentComponentSchema,
   },

--- a/src/scss/shims.scss
+++ b/src/scss/shims.scss
@@ -5,10 +5,21 @@
 // have higher priority/selectivity.
 :root {
   --utrecht-form-control-font-weight: var(--of-input-font-weight, initial);
-  // adds the quotes that the default styles are missing
-  --utrecht-unordered-list-list-style-type: '●';
+
+  // defaults for the unordered list component to be backwards compatible. Can be
+  // removed in Open Forms 5.0. (DeprecationWarning)
+  --utrecht-unordered-list-list-style-type: disc;
+  --utrecht-unordered-list-padding-inline-start: 18px;
+  --utrecht-unordered-list-margin-inline-start: 0;
+  --utrecht-unordered-list-item-padding-inline-start: 0;
 
   .utrecht-button {
     column-gap: var(--utrecht-button-column-gap, var(--utrecht-button-icon-gap));
   }
+}
+
+.openforms-theme {
+  // make explicit so that --utrecht-unordered-list-item-padding-inline-start isn't used
+  // as fallback, which results in a visual regression otherwise
+  --utrecht-ordered-list-item-padding-inline-start: 8px;
 }


### PR DESCRIPTION
Partly closes open-formulieren/open-forms#6410

Define fallback values that match the non-NL DS based components from earlier versions. See commit open-formulieren/design-tokens@004aed328d957690d856a7a18b58acda03b76a03 and open-formulieren/design-tokens@5e8d754e86886f6eb18bb28f435e52b9a2e85adc for more details. In a nutshell:

* font-size issues
* vertical alignment issues if the font-size gets fixed
* horizontal spacing off