### PR TITLE
Track parent-child relations of components

### DIFF
--- a/src/formio.spec.ts
+++ b/src/formio.spec.ts
@@ -423,6 +423,60 @@ describe('The getComponentsMap utility', () => {
     expect(map.sibling.id).toBe('content1');
     expect(map).toHaveProperty('editgrid');
   });
+
+  test('tracks parent-child relationships', () => {
+    const components: AnyComponentSchema[] = [
+      {
+        type: 'textfield',
+        key: 'my.textfield',
+        id: 'text1',
+        label: 'A text field',
+      } satisfies TextFieldComponentSchema,
+      {
+        type: 'fieldset',
+        key: 'container',
+        id: 'fieldset1',
+        label: 'A fieldset',
+        hideHeader: false,
+        components: [
+          {
+            type: 'email',
+            key: 'my.email',
+            id: 'email1',
+            label: 'An email field',
+          } satisfies EmailComponentSchema,
+          {
+            type: 'columns',
+            key: 'columnsLayout',
+            id: 'columns1',
+            columns: [
+              {
+                size: 12,
+                sizeMobile: 4,
+                components: [
+                  {
+                    type: 'content',
+                    key: 'wysiwyg',
+                    id: 'content1',
+                    html: '<p>Henlo</p>',
+                  } satisfies ContentComponentSchema,
+                ],
+              },
+            ],
+          } satisfies ColumnsComponentSchema,
+        ],
+      } satisfies FieldsetComponentSchema,
+    ];
+    const parentLinks: Record<string, string> = {};
+
+    getComponentsMap(components, parentLinks);
+
+    expect(parentLinks).toEqual({
+      wysiwyg: 'columnsLayout',
+      columnsLayout: 'container',
+      'my.email': 'container',
+    });
+  });
 });
 
 describe('isHidden utility', () => {

--- a/src/formio.ts
+++ b/src/formio.ts
@@ -137,6 +137,11 @@ export const getClearOnHide = (componentDefinition: AnyComponentSchema): boolean
   return true;
 };
 
+interface IterComponentsMeta {
+  parentLinks: Record<string, string>;
+  parentKey?: string;
+}
+
 /**
  * Recursively (and depth-first) iterate over all components in the component definition.
  *
@@ -152,18 +157,22 @@ export const getClearOnHide = (componentDefinition: AnyComponentSchema): boolean
  *   editgrid (an array of objects all with identical shape) itself, you cannot obtain
  *   the value of a particular nested component inside the items.
  */
-function* iterComponents(components: AnyComponentSchema[]): Generator<AnyComponentSchema> {
+function* iterComponents(
+  components: AnyComponentSchema[],
+  meta: IterComponentsMeta
+): Generator<AnyComponentSchema> {
   for (const component of components) {
+    if (meta.parentKey) meta.parentLinks[component.key] = meta.parentKey;
     yield component;
 
     switch (component.type) {
       case 'fieldset': {
-        yield* iterComponents(component.components);
+        yield* iterComponents(component.components, {...meta, parentKey: component.key});
         break;
       }
       case 'columns': {
         for (const column of component.columns) {
-          yield* iterComponents(column.components);
+          yield* iterComponents(column.components, {...meta, parentKey: component.key});
         }
         break;
       }
@@ -185,13 +194,17 @@ function* iterComponents(components: AnyComponentSchema[]): Generator<AnyCompone
  * introspect the matching component type/configuration.
  *
  * @param components The list of components to process.
+ * @param parentLinks Optional parameter to track the parent-child relationships of
+ *   the provided `components`. Keys are child component keys, values are the key of
+ *   their parent component.
  * @returns A flat map of component key to component definition.
  */
 export const getComponentsMap = (
-  components: AnyComponentSchema[]
+  components: AnyComponentSchema[],
+  parentLinks: Record<string, string> = {}
 ): Record<string, AnyComponentSchema> => {
   const map: Record<string, AnyComponentSchema> = {};
-  for (const component of iterComponents(components)) {
+  for (const component of iterComponents(components, {parentLinks})) {
     map[component.key] = component;
   }
   return map;
@@ -199,7 +212,7 @@ export const getComponentsMap = (
 
 function* iterDependencies(components: AnyComponentSchema[]): Generator<[string, string]> {
   // build a map of dependencies
-  for (const component of iterComponents(components)) {
+  for (const component of iterComponents(components, {parentLinks: {}})) {
     const conditional = getConditional(component);
     if (conditional !== null) {
       yield [component.key, conditional.when];


### PR DESCRIPTION
Necessary for the SDK to be able to look up the parent to inspect the hidden state when evaluating logic rules.

Was initially added, but then removed as the backend didn't need this when processing clearOnHide. Now that the behavior has been reworked, we actually do need it :)

(cherry picked from commit cc716d56c78166fd80cec4f95e7b4511755a95d2)