### PR TITLE
Fix dynamic options value type in Formik state

### DIFF
--- a/src/components/FormioForm.spec.tsx
+++ b/src/components/FormioForm.spec.tsx
@@ -1204,4 +1204,51 @@ describe('Regressions', () => {
     await expect.poll(() => onSubmit).toHaveBeenCalledOnce();
     expect(onSubmit).toHaveBeenCalledWith({selectboxes: {b: true}});
   });
+
+  // Suspected bug similar to open-formulieren/open-forms#6423
+  test('Selectboxes inside editgrid', async () => {
+    const onSubmit = vi.fn();
+    const screen = await render(
+      <Form
+        components={[
+          {
+            type: 'editgrid',
+            id: 'editgrid',
+            key: 'editgrid',
+            label: 'Repeating group',
+            disableAddingRemovingRows: false,
+            groupLabel: 'Item',
+            components: [
+              {
+                id: 'selectboxes',
+                type: 'selectboxes',
+                key: 'selectboxes',
+                label: 'Dynamic options',
+                values: [
+                  {value: 'a', label: 'A'},
+                  {value: 'b', label: 'B'},
+                ],
+                openForms: {dataSrc: 'manual'},
+              },
+            ],
+          },
+        ]}
+        values={{editgrid: []}}
+        onSubmit={onSubmit}
+      />
+    );
+
+    await screen.getByRole('button', {name: 'Add another'}).click();
+    await screen.getByRole('checkbox', {name: 'A', exact: true}).click();
+    await screen.getByRole('checkbox', {name: 'B', exact: true}).click();
+
+    // Save editgrid item and submit the form
+    await screen.getByRole('button', {name: 'Save'}).click();
+    await screen.getByRole('button', {name: 'Submit'}).click();
+    await expect
+      .poll(() => onSubmit)
+      .toHaveBeenCalledWith({
+        editgrid: [{selectboxes: {a: true, b: true}}],
+      });
+  });
 });

--- a/src/components/FormioForm.spec.tsx
+++ b/src/components/FormioForm.spec.tsx
@@ -1156,4 +1156,52 @@ describe('Regressions', () => {
     await expect.poll(() => onSubmit).toHaveBeenCalledOnce();
     expect(onSubmit).toHaveBeenCalledWith({selectboxes: {a: true, b: true}});
   });
+
+  // open-formulieren/open-forms#6420
+  test('Dynamic selectboxes items clear values of removed options', async () => {
+    const onSubmit = vi.fn();
+
+    const Test: React.FC = () => {
+      const [component, setComponent] = useState<SelectboxesComponentSchema>({
+        id: 'selectboxes',
+        type: 'selectboxes',
+        key: 'selectboxes',
+        label: 'Dynamic options',
+        values: [{value: 'a', label: 'A'}],
+        openForms: {dataSrc: 'manual'},
+      });
+      return (
+        <>
+          <Form components={[component]} onSubmit={onSubmit} />
+          <button
+            type="button"
+            onClick={() => {
+              setComponent({
+                ...component,
+                values: [{value: 'b', label: 'B'}],
+              });
+            }}
+          >
+            Update component options
+          </button>
+        </>
+      );
+    };
+
+    const screen = await render(<Test />);
+
+    await screen.getByRole('checkbox', {name: 'A', exact: true}).click();
+    await screen.getByRole('button', {name: 'Update component options'}).click();
+    await screen.getByRole('checkbox', {name: 'B', exact: true}).click();
+    await expect
+      .element(screen.getByRole('checkbox', {name: 'A', exact: true}))
+      .not.toBeInTheDocument();
+    await expect.element(screen.getByRole('checkbox', {name: 'B', exact: true})).toBeChecked();
+
+    const submitButton = screen.getByRole('button', {name: 'Submit'});
+    await expect.element(submitButton, {timeout: 1000}).toHaveAttribute('data-is-valid', 'true');
+    await screen.getByRole('button', {name: 'Submit'}).click();
+    await expect.poll(() => onSubmit).toHaveBeenCalledOnce();
+    expect(onSubmit).toHaveBeenCalledWith({selectboxes: {b: true}});
+  });
 });

--- a/src/components/FormioForm.spec.tsx
+++ b/src/components/FormioForm.spec.tsx
@@ -1,6 +1,7 @@
 import type {
   AnyComponentSchema,
   EditGridComponentSchema,
+  SelectboxesComponentSchema,
   TextFieldComponentSchema,
 } from '@open-formulieren/types';
 import {useFormikContext} from 'formik';
@@ -1103,5 +1104,56 @@ describe('Regressions', () => {
           },
         ],
       });
+  });
+
+  // open-formulieren/open-forms#6420
+  test('Dynamic selectboxes items produce boolean values', async () => {
+    const onSubmit = vi.fn();
+
+    const Test: React.FC = () => {
+      const [component, setComponent] = useState<SelectboxesComponentSchema>({
+        id: 'selectboxes',
+        type: 'selectboxes',
+        key: 'selectboxes',
+        label: 'Dynamic options',
+        values: [{value: 'a', label: 'A'}],
+        openForms: {dataSrc: 'manual'},
+      });
+      return (
+        <>
+          <Form components={[component]} onSubmit={onSubmit} />
+          <button
+            type="button"
+            onClick={() => {
+              setComponent({
+                ...component,
+                values: [
+                  {value: 'a', label: 'A'},
+                  {value: 'b', label: 'B'},
+                ],
+              });
+            }}
+          >
+            Update component options
+          </button>
+        </>
+      );
+    };
+
+    const screen = await render(<Test />);
+
+    await screen.getByRole('checkbox', {name: 'A', exact: true}).click();
+    await screen.getByRole('button', {name: 'Update component options'}).click();
+    await screen.getByRole('checkbox', {name: 'B', exact: true}).click();
+    await expect.element(screen.getByRole('checkbox', {name: 'A', exact: true})).toBeChecked();
+    await expect.element(screen.getByRole('checkbox', {name: 'B', exact: true})).toBeChecked();
+
+    // actual regression test -> submit and verify that we get booleans in the submission
+    // data
+    const submitButton = screen.getByRole('button', {name: 'Submit'});
+    await expect.element(submitButton, {timeout: 1000}).toHaveAttribute('data-is-valid', 'true');
+    await screen.getByRole('button', {name: 'Submit'}).click();
+    await expect.poll(() => onSubmit).toHaveBeenCalledOnce();
+    expect(onSubmit).toHaveBeenCalledWith({selectboxes: {a: true, b: true}});
   });
 });

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -6,7 +6,7 @@ import {FieldConfigContext, FormSettingsContext} from './context';
 export const useFormSettings = () => useContext(FormSettingsContext);
 
 /**
- * Given the field config context, calculated the (possibly) prefixed name.
+ * Given the field config context, calculate the (possibly) prefixed name.
  *
  * The prefix (if provided) is prepended with a `.` separator.
  *

--- a/src/registry/selectboxes/index.tsx
+++ b/src/registry/selectboxes/index.tsx
@@ -2,14 +2,14 @@ import type {SelectboxesComponentSchema} from '@open-formulieren/types';
 import {Fieldset, FieldsetLegend} from '@utrecht/fieldset-react';
 import {clsx} from 'clsx';
 import {useField, useFormikContext} from 'formik';
-import {useEffect, useId, useRef} from 'react';
+import {useEffect, useId, useMemo, useRef} from 'react';
 
 import Checkbox from '@/components/forms/Checkbox';
 import HelpText from '@/components/forms/HelpText';
 import {LabelContent} from '@/components/forms/Label';
 import Tooltip from '@/components/forms/Tooltip';
 import ValidationErrors from '@/components/forms/ValidationErrors';
-import type {RegistryEntry} from '@/registry/types';
+import type {GetRegistryEntry, RegistryEntry} from '@/registry/types';
 
 import ValueDisplay from './ValueDisplay';
 import testConditional from './conditional';
@@ -19,16 +19,25 @@ import getValidationSchema from './validationSchema';
 
 export interface FormioSelectboxesProps {
   componentDefinition: SelectboxesComponentSchema;
+  getRegistryEntry: GetRegistryEntry;
 }
 
-export const FormioSelectboxes: React.FC<FormioSelectboxesProps> = ({componentDefinition}) => {
+export const FormioSelectboxes: React.FC<FormioSelectboxesProps> = ({
+  componentDefinition,
+  getRegistryEntry,
+}) => {
   const {key, label, tooltip, description, validate = {}, values: options} = componentDefinition;
   const {required = false, maxSelectedCount} = validate;
   const {getFieldProps, getFieldMeta, validateField} = useFormikContext();
-  const [{value: selectboxesState = {}}, {error = ''}] = useField<{string: boolean} | undefined>(
-    key
-  );
+  const [{value: selectboxesState = {}}, {error = ''}, {setValue}] = useField<
+    Record<string, boolean> | undefined
+  >(key);
   const id = useId();
+
+  const initialValues: Record<string, boolean> = useMemo(
+    () => getInitialValues(componentDefinition, getRegistryEntry)[componentDefinition.key],
+    [getRegistryEntry, componentDefinition]
+  );
 
   const fieldsetRef = useRef<HTMLDivElement | null>(null);
   const lastValidatedValueRef = useRef<Record<string, boolean> | null>(null);
@@ -40,6 +49,29 @@ export const FormioSelectboxes: React.FC<FormioSelectboxesProps> = ({componentDe
     const {touched} = getFieldMeta<boolean>(nestedFieldName);
     return touched;
   });
+
+  // 🩹 - options can be changed dynamically and we need to ensure when they change,
+  // that new options are properly injected into the Formik state, otherwise we lose the
+  // boolean nature of the value and browser defaults (``[on]```) are used.
+  // See open-formulieren/open-forms#6420
+  useEffect(() => {
+    const updatedValue: Record<string, boolean> = selectboxesState;
+    let hasUpdates = false;
+    // check which options aren't in the state yet and add them with their initial value
+    // if necessary
+    for (const {value} of options) {
+      if (updatedValue[value] === undefined) {
+        updatedValue[value] = initialValues[value];
+        hasUpdates = true;
+      }
+    }
+
+    // TODO: ensure that removed options are *not* in the Formik state any longer!
+
+    if (hasUpdates) {
+      setValue(updatedValue);
+    }
+  }, [setValue, options, selectboxesState, initialValues]);
 
   // track the focus state of the fieldset and its children - when it loses focus, trigger
   // validation

--- a/src/registry/selectboxes/index.tsx
+++ b/src/registry/selectboxes/index.tsx
@@ -52,21 +52,29 @@ export const FormioSelectboxes: React.FC<FormioSelectboxesProps> = ({
 
   // 🩹 - options can be changed dynamically and we need to ensure when they change,
   // that new options are properly injected into the Formik state, otherwise we lose the
-  // boolean nature of the value and browser defaults (``[on]```) are used.
+  // boolean nature of the value and browser defaults (``[on]``) are used.
   // See open-formulieren/open-forms#6420
   useEffect(() => {
     const updatedValue: Record<string, boolean> = selectboxesState;
+    const optionKeysPresentInValue = new Set(Object.keys(updatedValue));
     let hasUpdates = false;
+
     // check which options aren't in the state yet and add them with their initial value
     // if necessary
     for (const {value} of options) {
-      if (updatedValue[value] === undefined) {
+      if (optionKeysPresentInValue.has(value)) {
+        optionKeysPresentInValue.delete(value);
+      } else {
         updatedValue[value] = initialValues[value];
         hasUpdates = true;
       }
     }
 
-    // TODO: ensure that removed options are *not* in the Formik state any longer!
+    // remove stale values from options that are obsoleted
+    if (!hasUpdates && optionKeysPresentInValue.size > 0) hasUpdates = true;
+    for (const staleValue of optionKeysPresentInValue) {
+      delete updatedValue[staleValue];
+    }
 
     if (hasUpdates) {
       setValue(updatedValue);


### PR DESCRIPTION
Closes open-formulieren/open-forms#6420

Ensure that the Formik field(s) state is in sync with the available options for selectboxes.

This is a problem only for the selectboxes component because it has a weird datastructure of `Record<string, boolean>`, which leads to a Formik field leaf node for each option on the component. Radio & select don't have that issue, because their option names don't end up in the field names.

The fix ensures that at all times the formik field names match the option values defined on the component.

**TODO**

- [x] Test if selectboxes work in editgrids, the same bug as for file uploads may be present
- [x] Test that option removal leads to it not being in the `onSubmit` values