### PR TITLE
Replace microscope-sass/lib/bem usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.24.0",
+        "@bbt/bem": "^1.0.1",
         "@floating-ui/react": "^0.27.7",
         "@formatjs/cli": "^6.5.1",
         "@formatjs/intl": "^3.1.8",
@@ -473,6 +474,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bbt/bem": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bbt/bem/-/bem-1.0.1.tgz",
+      "integrity": "sha512-9yMWdn6Dkbc1HSyzUdGGs06BRoOX0BkCJ6mPULdIUH+okY4FsX1Pt+WWQxPp+TtwKNYEVSIX/Bcr1IbH13UM+w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.24.0",
+    "@bbt/bem": "^1.0.1",
     "@floating-ui/react": "^0.27.7",
     "@formatjs/cli": "^6.5.1",
     "@formatjs/intl": "^3.1.8",

--- a/src/scss/bem.scss
+++ b/src/scss/bem.scss
@@ -1,5 +1,4 @@
-// use microscope-sass library for the time being, but extract the bem lib at some point.
-@forward 'microscope-sass/lib/bem';
+@forward '@bbt/bem';
 
 @use 'sass:list';
 @use 'sass:selector';


### PR DESCRIPTION
The @bbt/bem package contains an updated and maintained variant of the same functionality (it was originally standalone and got merged into microscope-sass at some point).